### PR TITLE
Fix Jenkins policies path error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,34 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+  apt_packages:
+    - build-essential
+    - python3-dev
+    - libldap2-dev
+    - libsasl2-dev
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: requirements.txt

--- a/cloud_governance/common/clouds/aws/s3/s3_operations.py
+++ b/cloud_governance/common/clouds/aws/s3/s3_operations.py
@@ -233,7 +233,7 @@ class S3Operations:
         try:
             if '_' in policy:
                 policy = policy.replace('_', '-')
-            date_key = datetime.datetime.now().strftime("%Y/%m/%d")
+            date_key = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime("%Y/%m/%d")
             objs = self.__s3_client.list_objects_v2(Bucket=bucket,
                                                     Prefix=f'{logs_bucket_key}/{policy}/{date_key}')['Contents']
         except:

--- a/jenkins/policies/run_policies.py
+++ b/jenkins/policies/run_policies.py
@@ -35,7 +35,7 @@ def get_custodian_policies(type: str = None):
     @return: list of custodian policies name
     """
     custodian_policies = []
-    policies_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'cloud_governance', 'policy', 'aws')
+    policies_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'cloud_governance', 'policy', 'aws')
     for (dirpath, dirnames, filenames) in os.walk(policies_path):
         for filename in filenames:
             if not filename.startswith('__') and (filename.endswith('.yml') or filename.endswith('.py')):

--- a/jenkins/policies/run_upload_es.py
+++ b/jenkins/policies/run_upload_es.py
@@ -27,7 +27,7 @@ def get_custodian_policies(type: str = None):
     @return: list of custodian policies name
     """
     custodian_policies = []
-    policies_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'cloud_governance', 'policy', 'aws')
+    policies_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'cloud_governance', 'policy', 'aws')
     for (dirpath, dirnames, filenames) in os.walk(policies_path):
         for filename in filenames:
             if not filename.startswith('__') and (filename.endswith('.yml') or filename.endswith('.py')):


### PR DESCRIPTION
1. Fix Jenkins policies path error
2. Added .readthedocs.yaml for building the readthedocs with specified instructions.
3. Increase s3 bucket objects fetching from one day to two days.