### PR TITLE
Releasing the AWS version 1.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 1.0.435
+current_version = 1.1.0
 tag_name = v{current_version}
 message = GitHub Actions Build {current_version}
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os import path
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.435'
+__version__ = '1.1.0'
 
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
This release run *policies* against AWS account and upload result into ElasticSearch and visualize the result in dedicated Grafana dashboards. Cloud-Governance 1.1.0 supports Python 3.9 and higher.