### PR TITLE
Downgrade the SoftLayer version from 6.1.1 --> 6.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ google-api-python-client==2.57.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.5.2
 python-ldap==3.4.2
-SoftLayer==6.1.1
+SoftLayer==6.0.0

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'google-auth-httplib2==0.1.0',  # google drive
         'google-auth-oauthlib==0.5.2',  # google drive
         'python-ldap==3.4.2',  # ldapsearch
-        'SoftLayer==6.1.1',  # IBM SoftLayer
+        'SoftLayer==6.0.0',  # IBM SoftLayer
     ],
 
     setup_requires=['pytest', 'pytest-runner', 'wheel', 'coverage'],

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -6,4 +6,4 @@ pandas
 requests==2.27.1
 typeguard==2.13.3
 python-ldap==3.4.2
-SoftLayer==6.1.1
+SoftLayer==6.0.0


### PR DESCRIPTION
```
The conflict is caused by:
    c7n 0.9.14 depends on typing-extensions==3.10.0.2
    myst-parser 0.17.0 depends on typing-extensions
    rich 12.5.1 depends on typing-extensions<5.0 and >=4.0.0; python_version < "3.9"
```
This error is rectified by downgrading the SoftLayer package.