### PR TITLE
Error when fetching azure daily cost usage

### DIFF
--- a/cloud_governance/common/clouds/azure/cost_management/cost_management_operations.py
+++ b/cloud_governance/common/clouds/azure/cost_management/cost_management_operations.py
@@ -3,6 +3,7 @@ import datetime
 import time
 
 import pytz
+from azure.core.exceptions import HttpResponseError
 from azure.mgmt.costmanagement.models import QueryDataset, QueryAggregation, QueryTimePeriod, QueryGrouping
 
 from cloud_governance.common.clouds.azure.subscriptions.azure_operations import AzureOperations
@@ -33,8 +34,13 @@ class CostManagementOperations:
                 )
             })
             return response.as_dict()
-        except Exception as e:
-            print(e)
+        except HttpResponseError as e:
+            logger.error(e)
+            if e.status_code == 429:
+                time.sleep(10)
+                return self.get_usage(scope, start_date=start_date, end_date=end_date, granularity=granularity, **kwargs)
+        except Exception as err:
+            logger.error(err)
         return []
 
     @logger_time_stamp

--- a/tests/integration/cloud_governance/common/clouds/azure/cost_management/test_cost_management_operations.py
+++ b/tests/integration/cloud_governance/common/clouds/azure/cost_management/test_cost_management_operations.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from cloud_governance.common.clouds.azure.cost_management.cost_management_operations import CostManagementOperations
 
 
@@ -9,7 +11,13 @@ def test_get_usage():
     @return:
     """
     cost_management_operations = CostManagementOperations()
-    cost_usage_data = cost_management_operations.get_usage(scope=cost_management_operations.azure_operations.scope)
+    end_date = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+    start_date = end_date - datetime.timedelta(days=1)
+    granularity = 'Daily'
+    cost_usage_data = cost_management_operations.get_usage(scope=cost_management_operations.azure_operations.scope,
+                                                           start_date=start_date, end_date=end_date,
+                                                           granularity=granularity
+                                                           )
     assert cost_usage_data
 
 


### PR DESCRIPTION
1. Add sleep time of 10 seconds in case of getting e.status_code == 429  and rerun again the get_usage method.
2. Fetching only last 2 days for reducing response data.