### PR TITLE
Added the http response code error of azure reports

### DIFF
--- a/cloud_governance/common/clouds/azure/cost_management/cost_management_operations.py
+++ b/cloud_governance/common/clouds/azure/cost_management/cost_management_operations.py
@@ -80,6 +80,11 @@ class CostManagementOperations:
                     row_data[data_date] = data
             result['rows'] = list(row_data.values())
             return result
+        except HttpResponseError as e:
+            logger.error(e)
+            if e.status_code == 429:
+                time.sleep(10)
+                return self.get_usage(scope, start_date=start_date, end_date=end_date, granularity=granularity, **kwargs)
         except Exception as err:
-            logger.info(f'Error raised when fetching the forecasting results {err}')
-            return []
+            logger.error(err)
+        return []

--- a/tests/integration/cloud_governance/common/clouds/azure/cost_management/test_cost_management_operations.py
+++ b/tests/integration/cloud_governance/common/clouds/azure/cost_management/test_cost_management_operations.py
@@ -27,7 +27,7 @@ def test_get_forecast():
     @return:
     """
     cost_management_operations = CostManagementOperations()
-    end_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+    end_date = datetime.datetime.utcnow() + datetime.timedelta(days=1)
     start_date = end_date - datetime.timedelta(days=1)
     granularity = 'Daily'
     cost_forecast_data = cost_management_operations.get_forecast(scope=cost_management_operations.azure_operations.scope,


### PR DESCRIPTION
Calling Azure APIs continuously will raise an error **429** [ rate limit exceed ]. To handle this error, caught the 429 error and wait for 10s second before calling a second time. 