### PR TITLE
Fix GitHub Actions PR vulnerability

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -5,6 +5,7 @@ name: PR
 
 on:
   pull_request_target:
+    types: [labeled, opened]
     branches: [ main ]
 
 jobs:
@@ -14,6 +15,8 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.8', '3.9', '3.10' ]
+    # minimize potential vulnerabilities
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Directly giving the external users to trigger pr, will produce the major vulnerability issue. To reduce this attack, owners need to verify and add the label **ok-to-test** to trigger PR.