### PR TITLE
Removed the parallel execution

### DIFF
--- a/cloud_governance/common/clouds/aws/utils/utils.py
+++ b/cloud_governance/common/clouds/aws/utils/utils.py
@@ -1,4 +1,3 @@
-from multiprocessing import Process, cpu_count
 from typing import Callable
 
 import typeguard
@@ -73,17 +72,12 @@ class Utils:
         :return:
         """
         if tags:
-            proc = []
             bulk_resource_ids_list = self.__split_run_bulks(iterable=resource_ids, limit=self.__update_tag_bulks)  # split the aws resource_ids into batches
             co = 0
             cpu_based_resource_ids_list = self.__split_run_bulks(iterable=bulk_resource_ids_list, limit=self.__update_tag_bulks)
             for cpu_based_resource_ids_list in cpu_based_resource_ids_list:
                 for resource_ids_list in cpu_based_resource_ids_list:
-                    p = Process(target=self.__tag_resources, args=(client_method, resource_ids_list, tags, ))
+                    self.__tag_resources(client_method, resource_ids_list, tags)
                     co += 1
-                    p.start()
-                    proc.append(p)
-                for p in proc:
-                    p.join()
             return co
 


### PR DESCRIPTION
Removing the API call in parallel. There are some limitations to the parallel execution. 
If we call create_tags in parallel, there is a scenario that it exceeds the thread limit.

