### PR TITLE
Changed the name of the concurrency group

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -8,7 +8,7 @@ on:
     branches: [ main ]
 
 concurrency:
-  group: merge-queue
+  group: build_queue
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Changed the name of the GHA concurrency.group


## For security reasons, all pull requests need to be approved first before running any automated CI
