### PR TITLE
Fixed the create_date mapper in es

### DIFF
--- a/cloud_governance/policy/aws/cleanup/database_idle.py
+++ b/cloud_governance/policy/aws/cleanup/database_idle.py
@@ -47,7 +47,7 @@ class DatabaseIdle(AWSPolicyOperations):
                                                     cleanup_result=str(cleanup_result),
                                                     resource_action=self.RESOURCE_ACTION,
                                                     cloud_name=self._cloud_name,
-                                                    launch_time=str(create_date),
+                                                    create_date=str(create_date),
                                                     resource_type=db.get('DBInstanceClass'),
                                                     unit_price=unit_price,
                                                     resource_state=db.get('DBInstanceStatus')

--- a/cloud_governance/policy/helpers/abstract_policy_operations.py
+++ b/cloud_governance/policy/helpers/abstract_policy_operations.py
@@ -219,6 +219,8 @@ class AbstractPolicyOperations(ABC):
             resource_data.update({'RunningDays': kwargs.get('running_days')})
         if kwargs.get('volume_size'):
             resource_data.update({'VolumeSize': kwargs.get('volume_size')})
+        if kwargs.get('create_date'):
+            resource_data.update({'create_date': kwargs.get('create_date')})
 
         return resource_data
 


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Added the key `create_date` to fix the launch_time issue. However, launchtime is specific to the instance service.
<!--- Describe your changes below -->
```
elasticsearch.exceptions.RequestError: RequestError(400, 'mapper_parsing_exception', "failed to parse field [LaunchTime] of type [date] in document with id '2024-06-09-aws-perfscale-us-west-2-standardization-db-available'. Preview of field's value: '2022-07-11 08:02:09.914000+00:00'")
```


## For security reasons, all pull requests need to be approved first before running any automated CI
