### PR TITLE
Fixed the numpy and ebs_in_use issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ azure-mgmt-resource==23.0.1
 azure-mgmt-subscription==3.1.1
 boto3==1.26.4
 botocore==1.29.4
-elasticsearch==7.11.0
+elasticsearch==7.17.9
 elasticsearch-dsl==7.4.0
 google-api-python-client==2.57.0
 google-auth-httplib2==0.1.0

--- a/tests/unittest/cloud_governance/aws/zombie_non_cluster/test_ebs_in_use.py
+++ b/tests/unittest/cloud_governance/aws/zombie_non_cluster/test_ebs_in_use.py
@@ -1,4 +1,3 @@
-import os
 
 import boto3
 from moto import mock_ec2, mock_s3
@@ -6,8 +5,7 @@ from moto import mock_ec2, mock_s3
 from cloud_governance.common.clouds.aws.s3.s3_operations import S3Operations
 from cloud_governance.main.environment_variables import environment_variables
 from cloud_governance.policy.aws.ebs_in_use import EbsInUse
-
-os.environ['AWS_DEFAULT_REGION'] = 'us-east-2'
+from tests.unittest.configs import AWS_DEFAULT_REGION
 
 
 @mock_ec2
@@ -17,8 +15,8 @@ def test_ebs_in_use():
     @return:
     """
     environment_variables.environment_variables_dict['policy'] = 'ebs_in_use'
-    region = os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')
-    ec2_client = boto3.client('ec2', region_name=region)
+    environment_variables.environment_variables_dict['AWS_DEFAULT_REGION'] = AWS_DEFAULT_REGION
+    ec2_client = boto3.client('ec2', region_name=AWS_DEFAULT_REGION)
     volume_id = ec2_client.create_volume(Size=10, AvailabilityZone='us-east-1a')['VolumeId']
     default_ami_id = 'ami-03cf127a'
     instance_id = ec2_client.run_instances(ImageId=default_ami_id, InstanceType='t2.micro', MaxCount=1, MinCount=1)['Instances'][0]['InstanceId']
@@ -36,8 +34,8 @@ def test_ebs_in_use_s3_upload():
     @return:
     """
     environment_variables.environment_variables_dict['policy'] = 'ebs_in_use'
-    region = os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')
-    ec2_client = boto3.client('ec2', region_name=region)
+    environment_variables.environment_variables_dict['AWS_DEFAULT_REGION'] = AWS_DEFAULT_REGION
+    ec2_client = boto3.client('ec2', region_name=AWS_DEFAULT_REGION)
     default_ami_id = 'ami-03cf127a'
     ec2_client.run_instances(ImageId=default_ami_id, InstanceType='t2.micro', MaxCount=1, MinCount=1)
     s3_client = boto3.client('s3', region_name='us-east-1')

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -5,7 +5,7 @@ azure-mgmt-costmanagement==3.0.0
 azure-mgmt-monitor==6.0.2
 azure-mgmt-subscription==3.1.1
 boto3==1.26.4
-elasticsearch==7.11.0
+elasticsearch==7.17.9
 elasticsearch-dsl==7.4.0
 freezegun==1.5.1
 moto==4.0.1


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Fixed the numpy and ebs_in_use issue
numpy:
```E   AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
```
To resolve above error, need to upgrade the elasticsearch
<!--- Describe your changes below -->


## For security reasons, all pull requests need to be approved first before running any automated CI
