### PR TITLE
Fix the elasticsearch, numpy versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ azure-mgmt-resource==23.0.1
 azure-mgmt-subscription==3.1.1
 boto3==1.26.4
 botocore==1.29.4
-elasticsearch==7.17.9
+elasticsearch==7.13.4 # opensearch 1.2.4 for elasticsearch
 elasticsearch-dsl==7.4.0
 google-api-python-client==2.57.0
 google-auth-httplib2==0.1.0
@@ -19,6 +19,7 @@ google-cloud-bigquery==3.5.0
 google-cloud-billing==1.9.1
 ibm_platform_services==0.27.0
 myst-parser==1.0.0
+numpy<=1.26.4 # opensearch 1.2.4 for elasticsearch
 oauthlib~=3.1.1
 pandas
 PyAthena[Pandas]==3.0.5

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,14 @@ setup(
         'azure-mgmt-billing==6.0.0',  # azure billing management
         'azure-mgmt-costmanagement==3.0.0',  # azure cost management
         'azure-mgmt-subscription==3.1.1',  # azure subscriptions
+        'azure-mgmt-resource==23.0.1',
+        'azure-mgmt-compute==30.1.0',
+        'azure-mgmt-network==25.0.0',
+        'azure-mgmt-monitor==6.0.2',
         'boto3==1.26.4',  # required by c7n 0.9.14
         'botocore==1.29.4',  # required by c7n 0.9.14
         'elasticsearch-dsl==7.4.0',
-        'elasticsearch==7.17.9',  # depend on elasticsearch server
+        'elasticsearch==7.13.4',  # opensearch 1.2.4 for elasticsearch
         'google-api-python-client==2.57.0',  # google drive
         'google-auth-httplib2==0.1.0',  # google drive
         'google-auth-oauthlib==0.5.2',  # google drive
@@ -57,6 +61,7 @@ setup(
         'google-cloud-billing==1.9.1',  # google cloud cost
         'ibm_platform_services==0.27.0',  # IBM Usage reports
         'myst-parser==1.0.0',  # readthedocs
+        'numpy<=1.26.4',  # opensearch 1.2.4 for elasticsearch
         'oauthlib~=3.1.1',  # required by jira
         'pandas',  # latest: aggregate ec2/ebs cluster data
         'PyAthena[Pandas]==3.0.5',  # AWS Athena package
@@ -70,11 +75,7 @@ setup(
         'sphinx==5.0.0',  # readthedocs
         'typeguard==2.13.3',  # checking types
         'typing==3.7.4.3',
-        'urllib3==1.26.19',  # required by jira
-        'azure-mgmt-resource==23.0.1',
-        'azure-mgmt-compute==30.1.0',
-        'azure-mgmt-network==25.0.0',
-        'azure-mgmt-monitor==6.0.2'
+        'urllib3==1.26.19'  # required by jira
     ],
 
     setup_requires=['pytest', 'pytest-runner', 'wheel', 'coverage'],

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -5,10 +5,11 @@ azure-mgmt-costmanagement==3.0.0
 azure-mgmt-monitor==6.0.2
 azure-mgmt-subscription==3.1.1
 boto3==1.26.4
-elasticsearch==7.17.9
+elasticsearch==7.13.4
 elasticsearch-dsl==7.4.0
 freezegun==1.5.1
 moto==4.0.1
+numpy<=1.26.4
 oauthlib~=3.1.1
 pandas
 pre-commit==3.5.0


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description

elastic search client version must satisfy the host version. 

python=3.8 :
numpy must be at 1.24.4 
So added numpy<=1.26.4 to support for all versions

<!--- Describe your changes below -->


## For security reasons, all pull requests need to be approved first before running any automated CI
