### PR TITLE
Multiprocessing support for MAC

### DIFF
--- a/cloud_governance/main/main.py
+++ b/cloud_governance/main/main.py
@@ -1,4 +1,7 @@
 import os
+import platform
+from multiprocessing import set_start_method
+
 import typeguard
 from ast import literal_eval  # str to dict
 import boto3  # regions
@@ -328,4 +331,9 @@ def main():
                     run_policy(account=account, policy=policy, region=region_env, dry_run=dry_run)
 
 
-main()
+if __name__ == '__main__':
+    # spawn default in mac:
+    # https://docs.python.org/3/library/multiprocessing.html#:~:text=The%20default%20on%20Windows%20and%20macOS.
+    if 'macos' in platform.platform(terse=True).lower():
+        set_start_method('fork')
+    main()


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Currently, there is no option to run multiprocessing tasks on a Mac without issues.
Adding set_start_method('fork') is necessary because the default method is spawn.
[For more details](https://docs.python.org/3/library/multiprocessing.html#:~:text=The%20default%20on%20Windows%20and%20macOS.)
<!--- Describe your changes below -->


## For security reasons, all pull requests need to be approved first before running any automated CI
