### PR TITLE
Fixed the zombie_cluster global resources

### DIFF
--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
@@ -6,7 +6,8 @@ from cloud_governance.common.clouds.aws.ec2.ec2_operations import EC2Operations
 from cloud_governance.common.clouds.aws.utils.common_methods import get_tag_value_from_tags
 from cloud_governance.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
 from cloud_governance.main.environment_variables import environment_variables
-from cloud_governance.policy.policy_operations.aws.zombie_cluster.zombie_cluster_common_methods import ZombieClusterCommonMethods
+from cloud_governance.policy.policy_operations.aws.zombie_cluster.zombie_cluster_common_methods import \
+    ZombieClusterCommonMethods
 from cloud_governance.common.logger.init_logger import logger
 from cloud_governance.common.logger.logger_time_stamp import logger_time_stamp
 from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterResources
@@ -54,8 +55,9 @@ def __get_resource_list(region, delete: bool = False, resource: str = '', cluste
                                     zombie_cluster_resources.zombie_cluster_subnet,
                                     zombie_cluster_resources.zombie_cluster_vpc
                                     ]
-    iam_zombie_resource_services = [zombie_cluster_resources.zombie_cluster_role,
-                                    zombie_cluster_resources.zombie_cluster_user]
+    iam_zombie_resource_services = [zombie_cluster_resources.zombie_cluster_role]
+    # user_delete permission is very problematic operation, it might affect other users.
+    # [zombie_cluster_resources.zombie_cluster_user]
     s3_zombie_resource_services = [zombie_cluster_resources.zombie_cluster_s3_bucket]
     scan_func_resource_list = []
     delete_func_resource_list = []
@@ -116,6 +118,7 @@ def zombie_cluster_resource(delete: bool = False, region: str = 'us-east-2', res
     zombie_cluster_common_methods = ZombieClusterCommonMethods(region=region)
     cluster_delete_days = {}
     zombie_cluster_resources_ids = {}
+    zombie_cluster_resources_data = {}
     for func in func_resource_list:
         resource_data, cluster_left_out_days = func()
         if resource_data:
@@ -127,7 +130,9 @@ def zombie_cluster_resource(delete: bool = False, region: str = 'us-east-2', res
             for resource_id, cluster_name in resource_data.items():
                 zombie_cluster_resources_ids.setdefault(cluster_name.strip(), []).append(resource_id)
                 cluster_delete_days[cluster_name] = get_tag_value_from_tags(tag_name='ClusterDeleteDays',
-                                                                            tags=cluster_left_out_days.get(cluster_name, []))
+                                                                            tags=cluster_left_out_days.get(cluster_name,
+                                                                                                           []))
+                zombie_cluster_resources_data.setdefault(cluster_name, []).append(func.__name__)
             resource_data_list = [func.__name__.replace("zombie_cluster_", "") + ':' + item for item in
                                   resource_data_list]
             logger.info(f'key: {func.__name__}, count: {len(resource_data)}, data: {resource_data_list}')
@@ -147,13 +152,25 @@ def zombie_cluster_resource(delete: bool = False, region: str = 'us-east-2', res
         es_index = environment_variables_dict.get('es_index')
         account = environment_variables_dict.get('account', '')
         if zombie_cluster_result:
+            regional_zombie_cluster_ids = []
+            global_zombie_cluster_resources = ['zombie_cluster_role', 'zombie_cluster_s3_bucket']
+            for zombie_cluster_id, resources_data in zombie_cluster_resources_data.items():
+                if (len(resources_data) > 0 and resources_data[0] in global_zombie_cluster_resources) \
+                        or (len(resources_data) > 1 and resources_data[1] in global_zombie_cluster_resources):
+                    if region == 'us-east-1':
+                        regional_zombie_cluster_ids.append(zombie_cluster_id)
+                    else:
+                        continue
+                else:
+                    regional_zombie_cluster_ids.append(zombie_cluster_id)
             for zombie_cluster in zombie_cluster_result:
-                zombie_cluster['region_name'] = region
-                zombie_cluster['account'] = account
-                zombie_cluster['ResourceIds'] = zombie_cluster_resources_ids[zombie_cluster['ResourceId']]
-                zombie_cluster['CleanUpDays'] = cluster_delete_days[zombie_cluster['ZombieClusterTag']]
-                es_operations.upload_to_elasticsearch(data=zombie_cluster.copy(), index=es_index)
-                logger.info(f'Uploaded the policy results to elasticsearch index: {es_index}')
+                if zombie_cluster['ZombieClusterTag'] in regional_zombie_cluster_ids:
+                    zombie_cluster['region_name'] = region
+                    zombie_cluster['account'] = account
+                    zombie_cluster['ResourceIds'] = zombie_cluster_resources_ids[zombie_cluster['ResourceId']]
+                    zombie_cluster['CleanUpDays'] = cluster_delete_days[zombie_cluster['ZombieClusterTag']]
+                    es_operations.upload_to_elasticsearch(data=zombie_cluster.copy(), index=es_index)
+                    logger.info(f'Uploaded the policy results to elasticsearch index: {es_index}')
         else:
             logger.error(f'No data to upload on @{account}  at {datetime.utcnow()}')
     else:

--- a/tests/integration/cloud_governance/aws/zombie_cluster/test_iam_zombie_delete.py
+++ b/tests/integration/cloud_governance/aws/zombie_cluster/test_iam_zombie_delete.py
@@ -1,46 +1,46 @@
-import uuid
-from datetime import datetime
-
-import boto3
-
-from cloud_governance.common.clouds.aws.utils.utils import Utils
-from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterResources
-
-
-def test_iam_zombie_user_create_and_delete():
-    """
-    This method checks weather the zombie users exists or not
-    :return:
-    """
-    short_random_id = uuid.uuid1()
-    time_ms = str(datetime.utcnow().strftime('%f'))
-    USER_NAME = f'integration-ocp-{short_random_id}-{time_ms}'
-    iam_resource = boto3.client('iam')
-    tags = [
-        {'Key': f'kubernetes.io/cluster/{USER_NAME}', 'Value': 'Owned'},
-        {'Key': 'Owner', 'Value': 'integration'}
-    ]
-    try:
-        iam_resource.create_user(UserName=USER_NAME, Tags=tags)
-        zombie_cluster_resources = ZombieClusterResources(cluster_prefix='kubernetes.io/cluster/', delete=False,
-                                                          cluster_tag=f'kubernetes.io/cluster/{USER_NAME}',
-                                                          resource_name='zombie_cluster_user', force_delete=True)
-        assert len(zombie_cluster_resources.zombie_cluster_user()) >= 1
-        zombie_cluster_resources = ZombieClusterResources(cluster_prefix='kubernetes.io/cluster/', delete=True,
-                                                          cluster_tag=f'kubernetes.io/cluster/{USER_NAME}',
-                                                          resource_name='zombie_cluster_user', force_delete=True)
-        zombie_cluster_resources.zombie_cluster_user()
-        iam_users = Utils().get_details_resource_list(func_name=iam_resource.list_users, input_tag='Users',
-                                                      check_tag='Marker')
-        find = False
-        for user in iam_users:
-            if user['UserName'] == USER_NAME:
-                find = True
-                break
-        assert not find
-    except Exception as err:
-        iam_users = Utils().get_details_resource_list(func_name=iam_resource.list_users, input_tag='Users', check_tag='Marker')
-        for user in iam_users:
-            if user['UserName'] == USER_NAME:
-                iam_resource.delete_user(UserName=USER_NAME)
-        raise Exception('Failed to delete User')
+# import uuid
+# from datetime import datetime
+#
+# import boto3
+#
+# from cloud_governance.common.clouds.aws.utils.utils import Utils
+# from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterResources
+#
+#
+# def test_iam_zombie_user_create_and_delete():
+#     """
+#     This method checks weather the zombie users exists or not
+#     :return:
+#     """
+#     short_random_id = uuid.uuid1()
+#     time_ms = str(datetime.utcnow().strftime('%f'))
+#     USER_NAME = f'integration-ocp-{short_random_id}-{time_ms}'
+#     iam_resource = boto3.client('iam')
+#     tags = [
+#         {'Key': f'kubernetes.io/cluster/{USER_NAME}', 'Value': 'Owned'},
+#         {'Key': 'Owner', 'Value': 'integration'}
+#     ]
+#     try:
+#         iam_resource.create_user(UserName=USER_NAME, Tags=tags)
+#         zombie_cluster_resources = ZombieClusterResources(cluster_prefix='kubernetes.io/cluster/', delete=False,
+#                                                           cluster_tag=f'kubernetes.io/cluster/{USER_NAME}',
+#                                                           resource_name='zombie_cluster_user', force_delete=True)
+#         assert len(zombie_cluster_resources.zombie_cluster_user()) >= 1
+#         zombie_cluster_resources = ZombieClusterResources(cluster_prefix='kubernetes.io/cluster/', delete=True,
+#                                                           cluster_tag=f'kubernetes.io/cluster/{USER_NAME}',
+#                                                           resource_name='zombie_cluster_user', force_delete=True)
+#         zombie_cluster_resources.zombie_cluster_user()
+#         iam_users = Utils().get_details_resource_list(func_name=iam_resource.list_users, input_tag='Users',
+#                                                       check_tag='Marker')
+#         find = False
+#         for user in iam_users:
+#             if user['UserName'] == USER_NAME:
+#                 find = True
+#                 break
+#         assert not find
+#     except Exception as err:
+#         iam_users = Utils().get_details_resource_list(func_name=iam_resource.list_users, input_tag='Users', check_tag='Marker')
+#         for user in iam_users:
+#             if user['UserName'] == USER_NAME:
+#                 iam_resource.delete_user(UserName=USER_NAME)
+#         raise Exception('Failed to delete User')

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_resources.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_resources.py
@@ -1,9 +1,10 @@
+from unittest import skip
 
 # TEST DRY RUN: delete=False
 from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterResources
 
-
-zombie_cluster_resources = ZombieClusterResources(cluster_prefix='kubernetes.io/cluster/', delete=False, region='us-east-2')
+zombie_cluster_resources = ZombieClusterResources(cluster_prefix='kubernetes.io/cluster/', delete=False,
+                                                  region='us-east-2')
 
 
 def test_all_clusters():
@@ -111,7 +112,7 @@ def test_zombie_cluster_internet_gateway():
     This method return all cluster internet_gateway
     :return:
     """
-    assert  len(zombie_cluster_resources.zombie_cluster_internet_gateway()[0]) >= 0
+    assert len(zombie_cluster_resources.zombie_cluster_internet_gateway()[0]) >= 0
 
 
 def test_zombie_cluster_dhcp_option():
@@ -154,6 +155,7 @@ def test_zombie_cluster_role():
     assert len(zombie_cluster_resources.zombie_cluster_role()[0]) >= 0
 
 
+@skip(reason='Skipping the zombie cluster user')
 def test_zombie_cluster_user():
     """
     This method return all zombie cluster user, scan cluster in all regions

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_iam_cluster_delete_resource.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_iam_cluster_delete_resource.py
@@ -1,11 +1,11 @@
 import json
+from unittest import skip
 
 from moto import mock_iam, mock_ec2
 import boto3
 
 from cloud_governance.common.clouds.aws.utils.utils import Utils
 from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterResources
-
 
 EC2_POLICY = {
     "Version": "2012-10-17",
@@ -48,25 +48,26 @@ def test_delete_iam_cluster_role():
     """
     iam_resource = boto3.client('iam')
     assume_role_policy_document = {
-                                    "Version": "2012-10-17",
-                                    "Statement": [
-                                        {
-                                            "Sid": "",
-                                            "Effect": "Allow",
-                                            "Principal": {
-                                                "Service": "ec2.amazonaws.com"
-                                            },
-                                            "Action": "sts:AssumeRole"
-                                        }
-                                    ]
-                                }
-    tags = [
-                {'Key': 'kubernetes.io/cluster/unittest-test-cluster', 'Value': 'Owned'},
-                {'Key': 'Owner', 'Value': 'unitest'}
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "ec2.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+            }
         ]
+    }
+    tags = [
+        {'Key': 'kubernetes.io/cluster/unittest-test-cluster', 'Value': 'Owned'},
+        {'Key': 'Owner', 'Value': 'unitest'}
+    ]
     iam_resource.create_role(AssumeRolePolicyDocument=json.dumps(assume_role_policy_document),
                              RoleName='unittest-ocp-test-worker-role', Tags=tags)
-    policy_output = iam_resource.create_policy(PolicyName='unittest-ocp-test-worker-policy', PolicyDocument=json.dumps(EC2_POLICY), Tags=tags)
+    policy_output = iam_resource.create_policy(PolicyName='unittest-ocp-test-worker-policy',
+                                               PolicyDocument=json.dumps(EC2_POLICY), Tags=tags)
     iam_resource.attach_role_policy(RoleName='unittest-ocp-test-worker-role', PolicyArn=policy_output['Policy']['Arn'])
 
     iam_resource.create_instance_profile(InstanceProfileName='unittest-ocp-test-worker-profile', Tags=tags)
@@ -76,8 +77,9 @@ def test_delete_iam_cluster_role():
     zombie_cluster_resources = ZombieClusterResources(cluster_prefix='kubernetes.io/cluster/', delete=True,
                                                       cluster_tag='kubernetes.io/cluster/unittest-test-cluster',
                                                       resource_name='zombie_cluster_role', force_delete=True)
-    zombie_cluster_resources. zombie_cluster_role()
-    iam_roles = Utils().get_details_resource_list(func_name=iam_resource.list_roles, input_tag='Roles', check_tag='Marker')
+    zombie_cluster_resources.zombie_cluster_role()
+    iam_roles = Utils().get_details_resource_list(func_name=iam_resource.list_roles, input_tag='Roles',
+                                                  check_tag='Marker')
     find = False
     for role in iam_roles:
         if role['RoleName'] == 'unittest-ocp-test-worker-role':
@@ -96,25 +98,26 @@ def test_not_delete_iam_cluster_role():
     """
     iam_resource = boto3.client('iam')
     assume_role_policy_document = {
-                                    "Version": "2012-10-17",
-                                    "Statement": [
-                                        {
-                                            "Sid": "",
-                                            "Effect": "Allow",
-                                            "Principal": {
-                                                "Service": "ec2.amazonaws.com"
-                                            },
-                                            "Action": "sts:AssumeRole"
-                                        }
-                                    ]
-                                }
-    tags = [
-                {'Key': 'kubernetes.io/cluster/unittest-test-cluster', 'Value': 'Owned'},
-                {'Key': 'Owner', 'Value': 'unitest'}
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "ec2.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+            }
         ]
+    }
+    tags = [
+        {'Key': 'kubernetes.io/cluster/unittest-test-cluster', 'Value': 'Owned'},
+        {'Key': 'Owner', 'Value': 'unitest'}
+    ]
     iam_resource.create_role(AssumeRolePolicyDocument=json.dumps(assume_role_policy_document),
                              RoleName='unittest-ocp-test-worker-role', Tags=tags)
-    policy_output = iam_resource.create_policy(PolicyName='unittest-ocp-test-worker-policy', PolicyDocument=json.dumps(EC2_POLICY), Tags=tags)
+    policy_output = iam_resource.create_policy(PolicyName='unittest-ocp-test-worker-policy',
+                                               PolicyDocument=json.dumps(EC2_POLICY), Tags=tags)
     iam_resource.attach_role_policy(RoleName='unittest-ocp-test-worker-role', PolicyArn=policy_output['Policy']['Arn'])
 
     iam_resource.create_instance_profile(InstanceProfileName='unittest-ocp-test-worker-profile', Tags=tags)
@@ -124,8 +127,9 @@ def test_not_delete_iam_cluster_role():
     zombie_cluster_resources = ZombieClusterResources(cluster_prefix='kubernetes.io/cluster/', delete=True,
                                                       cluster_tag='kubernetes.io/cluster/unittest-test-cluster',
                                                       resource_name='zombie_cluster_role')
-    zombie_cluster_resources. zombie_cluster_role()
-    iam_roles = Utils().get_details_resource_list(func_name=iam_resource.list_roles, input_tag='Roles', check_tag='Marker')
+    zombie_cluster_resources.zombie_cluster_role()
+    iam_roles = Utils().get_details_resource_list(func_name=iam_resource.list_roles, input_tag='Roles',
+                                                  check_tag='Marker')
     find = False
     for role in iam_roles:
         if role['RoleName'] == 'unittest-ocp-test-worker-role':
@@ -136,6 +140,7 @@ def test_not_delete_iam_cluster_role():
 
 @mock_ec2
 @mock_iam
+@skip(reason='Skipping the zombie cluster user')
 def test_delete_iam_cluster_user():
     """
     This method tests the user has successfully deleted or not
@@ -162,6 +167,7 @@ def test_delete_iam_cluster_user():
 
 @mock_ec2
 @mock_iam
+@skip(reason='Skipping the zombie cluster user')
 def test_not_delete_iam_cluster_user():
     """
     This method tests the user has not deleted


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
1. Skip the deletion of IAM User, as it is risky permission.
2. If the zombie_cluster has only IAM Role/ S3 bucket, upload to elastic search only if ran in region=us-east-1
<!--- Describe your changes below -->


## For security reasons, all pull requests need to be approved first before running any automated CI
