### PR TITLE
Added the tags to classic bm/vm

### DIFF
--- a/cloud_governance/common/clouds/ibm/account/ibm_account.py
+++ b/cloud_governance/common/clouds/ibm/account/ibm_account.py
@@ -31,6 +31,7 @@ class IBMAccount:
         self.__environment_variables_dict = environment_variables.environment_variables_dict
         self.__API_USERNAME = self.__environment_variables_dict.get('IBM_API_USERNAME', '')
         self.__API_KEY = self.__environment_variables_dict.get('IBM_API_KEY', '')
+        self.__sl_client = None
         try:
             if self.__API_KEY and self.__API_USERNAME:
                 self.__sl_client = SoftLayer.create_client_from_env(username=self.__API_USERNAME,

--- a/cloud_governance/common/clouds/ibm/classic/classic_operations.py
+++ b/cloud_governance/common/clouds/ibm/classic/classic_operations.py
@@ -2,6 +2,7 @@ from retry import retry
 from typeguard import typechecked
 
 from cloud_governance.common.clouds.ibm.account.ibm_account import IBMAccount
+from cloud_governance.common.jira.jira import logger
 from cloud_governance.common.logger.logger_time_stamp import logger_time_stamp
 
 
@@ -97,3 +98,55 @@ class ClassicOperations:
         """
         tags = self._sl_client.call('SoftLayer_Virtual_Guest', 'getTagReferences', id=vm_id)
         return self.__filter_tag_names(tag_references=tags)
+
+    def update_baremetal_tags(self, tags: list, hardware_id: str):
+        """
+        This method updates the hardware tags
+        :param tags:
+        :param hardware_id:
+        :return:
+        """
+        tag_names = []
+        for tag in tags:
+            key, value = tag.split(':')
+            tag_names.append(f"{key.strip()}:{value.strip()}")
+        error = ''
+        try:
+            response = self._sl_client.call('SoftLayer_Hardware_Server',
+                                            'setTags', ','.join(tag_names), id=hardware_id)
+            if response:
+                logger.info(f'Tags are added to the hardware: {hardware_id}  : {tag_names}')
+            else:
+                logger.error(
+                    f'Tags are not added to the hardware: {hardware_id} - , something might fail')
+        except Exception as err:
+            error = str(err)
+            response = False
+            logger.error(f'{err}')
+        return response, error
+
+    def update_virtual_machine_tags(self, tags: list, virtual_machine_id: str):
+        """
+        This method updates the virtual machine tags
+        :param tags:
+        :param virtual_machine_id:
+        :return:
+        """
+        tag_names = []
+        for tag in tags:
+            key, value = tag.split(':')
+            tag_names.append(f"{key.strip()}:{value.strip()}")
+        error = ''
+        try:
+            response = self._sl_client.call('SoftLayer_Virtual_Guest',
+                                            'setTags', ','.join(tag_names), id=virtual_machine_id)
+            if response:
+                logger.info(f'Tags are added to the VirtualMachine: {virtual_machine_id}  : {tags}')
+            else:
+                logger.error(
+                    f'Tags are not added to the VirtualMachine: {virtual_machine_id} - , something might fail')
+        except Exception as err:
+            error = str(err)
+            response = False
+            logger.error(f'{err}')
+        return response, error

--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -148,6 +148,8 @@ class EnvironmentVariables:
         self._environment_variables_dict['IBM_API_KEY'] = EnvironmentVariables.get_env('IBM_API_KEY', '')
         self._environment_variables_dict['USAGE_REPORTS_APIKEY'] = EnvironmentVariables.get_env('USAGE_REPORTS_APIKEY',
                                                                                                 '')
+        self._environment_variables_dict['IBM_CUSTOM_TAGS_LIST'] = EnvironmentVariables.get_env('IBM_CUSTOM_TAGS_LIST',
+                                                                                                '')
         self._environment_variables_dict['IBM_CLOUD_API_KEY'] = EnvironmentVariables.get_env('IBM_CLOUD_API_KEY', '')
 
         if (self._environment_variables_dict['USAGE_REPORTS_APIKEY'] or

--- a/cloud_governance/policy/policy_operations/ibm/tagging/tagging_operations.py
+++ b/cloud_governance/policy/policy_operations/ibm/tagging/tagging_operations.py
@@ -33,7 +33,15 @@ class TaggingOperations:
         tags = []
         for tag in user_tags:
             if tag not in resource_tags:
-                tags.append(tag)
+                if ',' in tag:
+                    multiple_tags = []
+                    for multiple_tag in tag.split(','):
+                        key, value = multiple_tag.split(':')
+                        multiple_tags.append(f"{key.strip()}:{value.strip()}")
+                    tags.extend(multiple_tags)
+                else:
+                    key, value = tag.split(':')
+                    tags.append(f"{key.strip()}:{value.strip()}")
         return tags
 
     def _filter_remove_tags(self, user_tags: list, resource_tags: list):
@@ -58,4 +66,4 @@ class TaggingOperations:
         @param tags:
         @return:
         """
-        return self._sl_client.call(softlayer_name,softlayer_method, tags, id=resource_id)
+        return self._sl_client.call(softlayer_name, softlayer_method, tags, id=resource_id)

--- a/jenkins/clouds/ibm/hourly/tagging/tagging.py
+++ b/jenkins/clouds/ibm/hourly/tagging/tagging.py
@@ -55,12 +55,12 @@ input_env_keys = {'account': account, 'LDAP_HOST_NAME': LDAP_HOST_NAME,
                   'log_level': "INFO", 'policy': 'tag_baremetal', "PUBLIC_CLOUD_NAME": "IBM", "tag_custom": tag_custom}
 
 baremetal_cmd = get_podman_run_cmd(volume_mounts=volume_mounts_targets, **input_env_keys)
-run_cmd(baremetal_cmd)
+# run_cmd(baremetal_cmd)
 
 run_cmd("echo Run IBM tag Virtual Machines")
 input_env_keys['policy'] = 'tag_vm'
 virtual_machine_cmd = get_podman_run_cmd(volume_mounts=volume_mounts_targets, **input_env_keys)
-run_cmd(virtual_machine_cmd)
+# run_cmd(virtual_machine_cmd)
 
 # Run tag resources
 run_cmd("echo Run tag resources command")
@@ -68,5 +68,7 @@ podman_run_cmd = get_podman_run_cmd(policy="tag_resources", account=account,
                                     IBM_CLOUD_API_KEY=IBM_CLOUD_API_KEY,
                                     IBM_CUSTOM_TAGS_LIST=IBM_CUSTOM_TAGS_LIST,
                                     PUBLIC_CLOUD_NAME="IBM",
-                                    IBM_ACCOUNT_ID=IBM_ACCOUNT_ID_PERFORMANCE_SCALE)
+                                    IBM_ACCOUNT_ID=IBM_ACCOUNT_ID_PERFORMANCE_SCALE,
+                                    IBM_API_USERNAME=IBM_API_USERNAME,
+                                    IBM_API_KEY=IBM_API_KEY, )
 run_cmd(podman_run_cmd)


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [] enhancement
- [ ] documentation
- [ ] dependencies

## Description
- This PR adds the ability to tag the classic bare metals/ virtual machines directly from the tag_resources policy instead of using a different policy.
- Fixed the trailing spaces on tags key and values.

<!--- Describe your changes below -->


## For security reasons, all pull requests need to be approved first before running any automated CI
