### PR TITLE
Add the postfix pod

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     hooks:
       - id: check-json
       - id: check-yaml
+        exclude: pod_yaml/postfix_pod.yml
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-added-large-files

--- a/Docker/postfix/Dockerfile
+++ b/Docker/postfix/Dockerfile
@@ -1,0 +1,25 @@
+# https://xc2.wb1.xyz/post/how-to-run-a-postfix-mail-server-in-a-docker-container/
+FROM alpine:3.13
+
+# Install dependencies
+RUN apk add --no-cache --update postfix cyrus-sasl ca-certificates bash && \
+    apk add --no-cache --upgrade musl musl-utils && \
+    # Clean up
+    (rm "/tmp/"* 2>/dev/null || true) && (rm -rf /var/cache/apk/* 2>/dev/null || true)
+
+# Mark used folders
+VOLUME [ "/var/spool/postfix", "/etc/postfix" ]
+
+# Expose mail submission agent port
+EXPOSE 587
+
+# Configure Postfix on startup
+COPY docker-entrypoint.sh /usr/local/bin/
+
+RUN chown postfix:postfix /etc/postfix /etc/postfix/main.cf && \
+    chmod 777 /usr/local/bin/docker-entrypoint.sh &&
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
+# Start postfix in foreground mode
+CMD ["postfix", "start-fg"]

--- a/Docker/postfix/docker-entrypoint.sh
+++ b/Docker/postfix/docker-entrypoint.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -e
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_PASSWORD' 'example'
+# (will allow for "$XYZ_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_PASSWORD" from a file, especially for Docker's secrets feature)
+# copied from mariadb docker entrypoint file
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+#file_env 'POSTFIX_RELAY_PASSWORD'
+
+#if [ -z "$POSTFIX_HOSTNAME" -a -z "$POSTFIX_RELAY_HOST" ]; then
+#    echo >&2 'error: relay options are not specified '
+#    echo >&2 '  You need to specify POSTFIX_HOSTNAME, POSTFIX_RELAY_HOST)'
+#    exit 1
+#fi
+
+# Create postfix folders
+mkdir -p /var/spool/postfix/
+mkdir -p /var/spool/postfix/pid
+
+# Disable SMTPUTF8, because libraries (ICU) are missing in Alpine
+postconf -e "smtputf8_enable=no"
+
+# Log to stdout
+postconf -e "maillog_file=/dev/stdout"
+
+# Update aliases database. It's not used, but postfix complains if the .db file is missing
+postalias /etc/postfix/aliases
+
+# Disable local mail delivery
+postconf -e "mydestination="
+
+# Limit message size to 10MB
+postconf -e "message_size_limit=10240000"
+
+# Reject invalid HELOs
+postconf -e "smtpd_delay_reject=yes"
+postconf -e "smtpd_helo_required=yes"
+postconf -e "smtpd_helo_restrictions=permit_mynetworks,reject_invalid_helo_hostname,permit"
+
+# Don't allow requests from outside
+postconf -e "mynetworks=127.0.0.0/8,${POSTFIX_ALLOWED_IPS}"
+
+# Set up hostname
+#postconf -e myhostname=$POSTFIX_HOSTNAME
+
+# Do not relay mail from untrusted networks
+postconf -e relay_domains=$POSTFIX_RELAY_DOMAINS
+
+# Relay configuration
+postconf -e relayhost=$POSTFIX_RELAY_HOST
+#echo "$POSTFIX_RELAY_HOST $POSTFIX_RELAY_USER:$POSTFIX_RELAY_PASSWORD" >> /etc/postfix/sasl_passwd
+#postmap lmdb:/etc/postfix/sasl_passwd
+#postconf -e "smtp_sasl_auth_enable=yes"
+#postconf -e "smtp_sasl_password_maps=lmdb:/etc/postfix/sasl_passwd"
+#postconf -e "smtp_sasl_security_options=noanonymous"
+#postconf -e "smtpd_recipient_restrictions=reject_non_fqdn_recipient,reject_unknown_recipient_domain,reject_unverified_recipient"
+
+# Use 587 (submission)
+sed -i -r -e 's/^#submission/submission/' /etc/postfix/master.cf
+
+echo
+echo 'postfix configured. Ready for start up.'
+echo
+
+exec "$@"

--- a/cloud_governance/common/mails/postfix.py
+++ b/cloud_governance/common/mails/postfix.py
@@ -42,6 +42,8 @@ class Postfix:
         self.__email_alert = self.__environment_variables_dict.get('EMAIL_ALERT')
         self.__mail_to = self.__environment_variables_dict.get('EMAIL_TO')
         self.__mail_cc = self.__environment_variables_dict.get('EMAIL_CC')
+        self.__POSTFIX_HOST = environment_variables.POSTFIX_HOST
+        self.__POSTFIX_PORT = environment_variables.POSTFIX_PORT
         self.bucket_name, self.key = self.get_bucket_name()
         self.__es_index = 'cloud-governance-mail-messages'
         if self.__es_host:
@@ -130,9 +132,8 @@ class Postfix:
             else:
                 msg.attach(MIMEText(content))
             email_string = msg.as_string()
-            email_host = 'localhost'
             try:
-                with smtplib.SMTP(email_host) as s:
+                with smtplib.SMTP(self.__POSTFIX_HOST, self.__POSTFIX_PORT) as s:
                     try:
                         logger.debug(email_string)
                         s.send_message(msg)

--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -74,7 +74,10 @@ class EnvironmentVariables:
             EnvironmentVariables.get_env('DAYS_TO_TAKE_ACTION', "7"))
         if not hasattr(self, 'POLICIES_LIST'):
             self.POLICIES_LIST = EnvironmentVariables.get_env('POLICIES_LIST')
-
+        if not hasattr(self, 'POSTFIX_HOST'):
+            self.POSTFIX_HOST = EnvironmentVariables.get_env('POSTFIX_HOST', 'localhost')
+        if not hasattr(self, 'POSTFIX_PORT'):
+            self.POSTFIX_PORT = int(EnvironmentVariables.get_env('POSTFIX_PORT', '25'))
         self._environment_variables_dict['PRINT_LOGS'] = EnvironmentVariables.get_boolean_from_environment('PRINT_LOGS',
                                                                                                            True)
         if not self._environment_variables_dict['AWS_DEFAULT_REGION']:

--- a/pod_yaml/postfix_pod.yml
+++ b/pod_yaml/postfix_pod.yml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: postfix
+    envType: production
+  name: postfix
+spec:
+  containers:
+    - env:
+        - name: POSTFIX_RELAY_DOMAINS
+          value: redhat.com
+        - name: POSTFIX_RELAY_HOST
+          value: smtp.corp.redhat.com
+      image: quay.io/athiru/postfix:v0.3
+      name: postfix
+      ports:
+        - containerPort: 25
+      resources: { }
+  dnsPolicy: ClusterFirst
+  restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: postfix
+    envType: production
+  name: postfix
+spec:
+  ports:
+    - name: postfix-tcp
+      port: 30002
+      protocol: TCP
+      targetPort: 25
+  selector:
+    app: postfix
+    envType: production


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [x] documentation
- [ ] dependencies

## Description
decouple the cloud-governance container and postfix service to its dedicated pod.

To use the postfix svc from the openshift cluster, export POSTFIX_HOST, and POSTFIX_PORT to the cloud-governance container.
<!--- Describe your changes below -->


## For security reasons, all pull requests need to be approved first before running any automated CI
