### PR TITLE
fix aggregate email alert

### DIFF
--- a/cloud_governance/common/mails/postfix.py
+++ b/cloud_governance/common/mails/postfix.py
@@ -156,10 +156,8 @@ class Postfix:
                 to = self.__mail_to
             if self.__mail_cc:
                 cc = self.__mail_cc
-            to = "yinsong@redhat.com"
-            cc = []
             if not self.__ldap_search.get_user_details(user_name=to):
-                cc.append('yinsong@redhat.com')
+                cc.extend(self.__default_admins)
             response = {'ok': True}
             to = self.prettify_to(to)
             cc = self.prettify_cc(cc)

--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -277,7 +277,7 @@ class EnvironmentVariables:
         self._environment_variables_dict['POLICY_ACTIONS_DAYS'] = literal_eval(
             EnvironmentVariables.get_env('POLICY_ACTIONS_DAYS', '[]'))
         self._environment_variables_dict['DEFAULT_ADMINS'] = literal_eval(
-            EnvironmentVariables.get_env('DEFAULT_ADMINS', '[]'))
+            EnvironmentVariables.get_env('DEFAULT_ADMINS', '["yinsong@redhat.com", "ebattat@redhat.com"]'))
         self._environment_variables_dict['KERBEROS_USERS'] = literal_eval(
             EnvironmentVariables.get_env('KERBEROS_USERS', '[]'))
         self._environment_variables_dict['POLICIES_TO_ALERT'] = literal_eval(


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
There is no aggregate email alerts at all because all was forwarding to 1 email.

## For security reasons, all pull requests need to be approved first before running any automated CI
