### PR TITLE
Fix skip policy alert

### DIFF
--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -283,7 +283,7 @@ class EnvironmentVariables:
             EnvironmentVariables.get_env('POLICIES_TO_ALERT', '[]'))
         self._environment_variables_dict['ADMIN_MAIL_LIST'] = EnvironmentVariables.get_env('ADMIN_MAIL_LIST', '')
         self._environment_variables_dict['SKIP_POLICIES_ALERT'] = literal_eval(
-            EnvironmentVariables.get_env('SKIP_POLICIES_ALERT', "['']"))
+            EnvironmentVariables.get_env('SKIP_POLICIES_ALERT', '[]'))
         if self._environment_variables_dict.get('policy') in ['send_aggregated_alerts', 'cloudability_cost_reports']:
             self._environment_variables_dict['COMMON_POLICIES'] = True
         # CRO -- Cloud Resource Orch

--- a/jenkins/tenant/aws/ecoeng_01/PolicyJenkinsfileDaily
+++ b/jenkins/tenant/aws/ecoeng_01/PolicyJenkinsfileDaily
@@ -41,7 +41,7 @@ pipeline {
         // By default, all policies are running in dry_run="yes" mode and the whole list can be found in run_policies.py
         // POLICIES_IN_ACTION: Policies that run in the dry_run="no" mode
         POLICIES_IN_ACTION = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "zombie_cluster_resource"]'
-        SKIP_POLICIES_ALERT = '["unused_access_key"]'
+        SKIP_POLICIES_ALERT = ["unused_access_key"]
     }
     stages {
         stage('Checkout') { // Checkout (git clone ...) the projects repository
@@ -80,7 +80,7 @@ pipeline {
                                         string(credentialsId: "${account}-aws-secret-key-id", variable: 'secret_key'),
                                         string(credentialsId: "${account}-s3-bucket", variable: 's3_bucket')]) {
                         if (account == 'industry-partners') {
-                            env.SKIP_POLICIES_ALERT = '[]'
+                            env.SKIP_POLICIES_ALERT = []
                         }
                         env.account_name = "${account}"
                         env.ADMIN_MAIL_LIST = "${accounts_list[account]}"

--- a/jenkins/tenant/aws/ecoeng_02/PolicyJenkinsfileDaily
+++ b/jenkins/tenant/aws/ecoeng_02/PolicyJenkinsfileDaily
@@ -29,7 +29,7 @@ pipeline {
         // By default, all policies are running in dry_run="yes" mode and the whole list can be found in run_policies.py
         // POLICIES_IN_ACTION: Policies that run in the dry_run="no" mode
         POLICIES_IN_ACTION = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "zombie_cluster_resource"]'
-        SKIP_POLICIES_ALERT = '["unused_access_key"]'
+        SKIP_POLICIES_ALERT = ["unused_access_key"]
     }
     stages {
         stage('Checkout') { // Checkout (git clone ...) the projects repository

--- a/jenkins/tenant/aws/ecoeng_03/PolicyJenkinsfileDaily
+++ b/jenkins/tenant/aws/ecoeng_03/PolicyJenkinsfileDaily
@@ -26,7 +26,7 @@ pipeline {
         // By default, all policies are running in dry_run="yes" mode and the whole list can be found in run_policies.py
         // POLICIES_IN_ACTION: Policies that run in the dry_run="no" mode
         POLICIES_IN_ACTION = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "zombie_cluster_resource"]'
-        SKIP_POLICIES_ALERT = '["unused_access_key"]'
+        SKIP_POLICIES_ALERT = ["unused_access_key"]
     }
     stages {
         stage('Checkout') { // Checkout (git clone ...) the projects repository


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Fix SKIP_POLICIES_ALERT from string to list
```
                            ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cloud_governance/main/environment_variables.py", line 285, in __init__
    self._environment_variables_dict['SKIP_POLICIES_ALERT'] = literal_eval(
                                                              ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ast.py", line 112, in literal_eval
    return _convert(node_or_string)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ast.py", line 92, in _convert
    return list(map(_convert, node.elts))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ast.py", line 111, in _convert
    return _convert_signed_num(node)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ast.py", line 85, in _convert_signed_num
    return _convert_num(node)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ast.py", line 76, in _convert_num
    _raise_malformed_node(node)
  File "/usr/local/lib/python3.12/ast.py", line 73, in _raise_malformed_node
    raise ValueError(msg + f': {node!r}')
ValueError: malformed node or string on line 1: <ast.Name object at 0x7f8a18fcb650>

```

## For security reasons, all pull requests need to be approved first before running any automated CI
