### PR TITLE
fix variable quotes

### DIFF
--- a/jenkins/tenant/aws/common/run_policies.py
+++ b/jenkins/tenant/aws/common/run_policies.py
@@ -128,4 +128,4 @@ run_cmd(
 # Run the AggMail
 
 run_cmd(
-    f"""podman run --rm --name cloud-governance-haim --net="host" -e account="{account_name}" -e policy="send_aggregated_alerts" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e LDAP_HOST_NAME="{LDAP_HOST_NAME}" -e SKIP_POLICIES_ALERT="{SKIP_POLICIES_ALERT}" -e log_level="INFO" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}" {env_es_index} -e ADMIN_MAIL_LIST="{ADMIN_MAIL_LIST}" -e ALERT_DRY_RUN="{ALERT_DRY_RUN}" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+    f"""podman run --rm --name cloud-governance-haim --net="host" -e account="{account_name}" -e policy="send_aggregated_alerts" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e LDAP_HOST_NAME="{LDAP_HOST_NAME}" -e SKIP_POLICIES_ALERT='{SKIP_POLICIES_ALERT}' -e log_level="INFO" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}" {env_es_index} -e ADMIN_MAIL_LIST="{ADMIN_MAIL_LIST}" -e ALERT_DRY_RUN="{ALERT_DRY_RUN}" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Fix variable quotes:
If SKIP_POLICIES_ALERT contains quotes or special characters (like [ or "), wrapping it again in double quotes inside the f-string can break things.
For example, if the env var is:
-e SKIP_POLICIES_ALERT="["unused_access_key"]"
which is invalid because the " inside the value clashes with the outer " — causing syntax issues or unexpected escaping.
Error:
`ValueError: malformed node or string on line 1: <ast.Name object at 0x7f88ee8ea2d0>`
## For security reasons, all pull requests need to be approved first before running any automated CI
