### PR TITLE
Fix and enhance the RESOURCE_TO_TAG option

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -69,7 +69,7 @@ Environment Variables required:
 | KeyName                    | Value  | Description                                                                |
 |----------------------------|--------|----------------------------------------------------------------------------|
 | IBM_CUSTOM_TAGS_LIST       | string | pass string with separated with comma. i.e: "cost-center: test, env: test" |
-| RESOURCE_TO_TAG (optional) | string | pass the resource name to tag. ex: virtual_servers                         |
+| RESOURCE_TO_TAG (optional) | string | pass the resource names to tag. ex: "virtual_servers,resource_instances"   |
 | IBM_CLOUD_API_KEY          | string | IBM Cloud API Key                                                          |
 | IBM_API_KEY                | string | IBM Classic infrastructure key ( SoftLayer )                               |
 | IBM_API_USERNAME           | string | IBM API Username ( SoftLayer )                                             |

--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -182,6 +182,8 @@ class EnvironmentVariables:
         self._environment_variables_dict['tag_remove_name'] = EnvironmentVariables.get_env('tag_remove_name', '')
         self._environment_variables_dict['tag_custom'] = EnvironmentVariables.get_env('tag_custom', '{}')
 
+        self._environment_variables_dict['RESOURCE_TO_TAG'] = EnvironmentVariables.get_env('RESOURCE_TO_TAG', '')
+
         # Common env vars
         self._environment_variables_dict['dry_run'] = EnvironmentVariables.get_env('dry_run', 'yes')
         self._environment_variables_dict['FORCE_DELETE'] = EnvironmentVariables.get_boolean_from_environment(

--- a/cloud_governance/policy/ibm/tag_resources.py
+++ b/cloud_governance/policy/ibm/tag_resources.py
@@ -107,7 +107,8 @@ class TagResources:
             "classic_virtual_machines"
         ]
         if self.resource_to_tag:
-            vpc_resources = list(set(vpc_resources) & set(self.resource_to_tag.split(',')))
+            resources_to_tag = [resource.strip() for resource in self.resource_to_tag.split(',')]
+            vpc_resources = list(set(vpc_resources) & set(resources_to_tag))
         logger.info(f"Running tag operation on total of {len(vpc_resources)} resources")
         errors = messages = {}
         for vpc_resource in vpc_resources:

--- a/cloud_governance/policy/ibm/tag_resources.py
+++ b/cloud_governance/policy/ibm/tag_resources.py
@@ -106,8 +106,8 @@ class TagResources:
             "classic_baremetals",
             "classic_virtual_machines"
         ]
-        if self.resource_to_tag and self.resource_to_tag in vpc_resources:
-            vpc_resources = [self.resource_to_tag]
+        if self.resource_to_tag:
+            vpc_resources = list(set(vpc_resources) & set(self.resource_to_tag.split(',')))
         logger.info(f"Running tag operation on total of {len(vpc_resources)} resources")
         errors = messages = {}
         for vpc_resource in vpc_resources:


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->

Fix: This environmental variable was ignored even if set.
Enchance: Add support for defining multiple, comma-separated resources.


## For security reasons, all pull requests need to be approved first before running any automated CI
