### PR TITLE
Fix skip policy alert

### DIFF
--- a/jenkins/tenant/aws/ecoeng_03/PolicyJenkinsfileDaily
+++ b/jenkins/tenant/aws/ecoeng_03/PolicyJenkinsfileDaily
@@ -26,7 +26,7 @@ pipeline {
         // By default, all policies are running in dry_run="yes" mode and the whole list can be found in run_policies.py
         // POLICIES_IN_ACTION: Policies that run in the dry_run="no" mode
         POLICIES_IN_ACTION = '["unused_access_key"]'
-        //SKIP_POLICIES_ALERT = '["unused_access_key"]'
+        SKIP_POLICIES_ALERT = '[]'
     }
     stages {
         stage('Checkout') { // Checkout (git clone ...) the projects repository


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
```
    environment_variables = EnvironmentVariables()
                            ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cloud_governance/main/environment_variables.py", line 285, in __init__
    self._environment_variables_dict['SKIP_POLICIES_ALERT'] = literal_eval(
                                                              ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ast.py", line 66, in literal_eval
    node_or_string = parse(node_or_string.lstrip(" \t"), mode='eval')
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ast.py", line 52, in parse
    return compile(source, filename, mode, flags,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<unknown>", line 0
```

## For security reasons, all pull requests need to be approved first before running any automated CI
