### PR TITLE
enable unused_access_key policy sap account

### DIFF
--- a/jenkins/tenant/aws/ecoeng_03/PolicyJenkinsfileDaily
+++ b/jenkins/tenant/aws/ecoeng_03/PolicyJenkinsfileDaily
@@ -25,7 +25,7 @@ pipeline {
         // Find the all available policies: https://github.com/redhat-performance/cloud-governance/tree/main/cloud_governance/policy
         // By default, all policies are running in dry_run="yes" mode and the whole list can be found in run_policies.py
         // POLICIES_IN_ACTION: Policies that run in the dry_run="no" mode
-        POLICIES_IN_ACTION = '[]'
+        POLICIES_IN_ACTION = '["unused_access_key"]'
         SKIP_POLICIES_ALERT = '[]'
     }
     stages {


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [x] documentation
- [ ] dependencies

## Description
<!--- Describe your changes below -->
Enable unused_access_key policy on ecoeng-sap account

## For security reasons, all pull requests need to be approved first before running any automated CI
