### PR TITLE
Fix coverage typo and remove duplicate coverage commands

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -51,7 +51,6 @@ jobs:
           BUCKET: ${{ secrets.BUCKET }}
           REGION: ${{ secrets.REGION }}
         run: |
-          pytest -v tests/unittest --cov=cloud_governqance --cov-report=term-missing
           coverage run -m pytest -v tests/unittest
           coverage report -m
       - name: 🎥 Publish to coveralls.io
@@ -182,7 +181,6 @@ jobs:
           GCP_DATABASE_NAME: ${{ secrets.GCP_DATABASE_NAME }}
           GCP_DATABASE_TABLE_NAME: ${{ secrets.GCP_DATABASE_TABLE_NAME }}
         run: |
-          pytest -v tests/integration --cov=cloud_governqance --cov-report=term-missing
           coverage run -m pytest -v tests/integration
           coverage report -m
       - name: 🎥 Publish to coveralls.io


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [X] enhancement
- [ ] documentation
- [ ] dependencies

## Description
- Fixed typo: cloud_governqance -> cloud_governance
- Removed duplicate pytest command (coverage run already runs pytest)
- Simplified both unittest and integration test coverage commands

## For security reasons, all pull requests need to be approved first before running any automated CI.