### PR TITLE
Operation not permitted while Detaching ENI

### DIFF
--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/delete_ec2_resources.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/delete_ec2_resources.py
@@ -381,10 +381,8 @@ class DeleteEC2Resources:
                 network_interface = network_interface_data[0]
                 tags = network_interface.get('TagSet', [])
                 if self.cluster_tag and not self.__is_cluster_resource(tags, self.cluster_tag):
-                    logger.info(f'Network interface {resource_id} is not a cluster resource. Skipping deletion.')
                     return
             else:
-                logger.warning(f'Network interface {resource_id} not found in resource list. Skipping deletion.')
                 return
 
             descriptions = self.__get_cluster_references(resource_id=resource_id, resource_list=resource_list,


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
ERROR: botocore.exceptions.ClientError: An error occurred (OperationNotPermitted) when calling the DetachNetworkInterface operation: The network interface at device index 0 and networkCard index 0 cannot be detached.
[ERROR] 2025-11-13 06:17:19,769 - Cannot disassociate_address: eni-02042ddb8b6xxxxxx, An error occurred (OperationNotPermitted) when calling the DetachNetworkInterface operation: The network interface at device index 0 and networkCard index 0 cannot be detached.

CAUSE: Getting error for operation not permitted because the script is trying to delete eni from running/stopped instances =, which shouldn't be the case. The filtering for zombie cluster resources was not properly filtering out such instances.

FIX: Added a check to verify whether the resource has a cluster tag before proceeding with detachment.


## For security reasons, all pull requests need to be approved first before running any automated CI
