### PR TITLE
Update log messaging for eni detach operation

### DIFF
--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/delete_ec2_resources.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/delete_ec2_resources.py
@@ -399,7 +399,15 @@ class DeleteEC2Resources:
                 self.client.delete_network_interface(NetworkInterfaceId=resource_id)
                 logger.info(f'delete_network_interface: {resource_id}')
         except Exception as err:
-            logger.exception(f'Cannot disassociate_address: {resource_id}, {err}')
+            error_message = str(err)
+            if 'OperationNotPermitted' in error_message and 'device index 0' in error_message.lower():
+                logger.info(f'Skipping deletion of network interface {resource_id}: primary interface (device index 0) '
+                          f'cannot be detached.')
+            elif 'OperationNotPermitted' in error_message:
+                logger.info(f'Skipping deletion of network interface {resource_id}: cannot detach network interface '
+                          f'attached to an active instance.')
+            else:
+                logger.exception(f'Cannot delete_network_interface: {resource_id}, {err}')
 
     def __delete_efs(self, resource_id: str):
         """


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description

Getting following error in Jenkins run for eni detach operation:

```[ERROR] 2025-11-19 06:15:04,502 perfscale - Cannot disassociate_address: eni-02172f7ae3cfb1b70, An error occurred (OperationNotPermitted) when calling the DetachNetworkInterface operation: The network interface at device index 0 and networkCard index 0 cannot be detached.```

The eni's cannot be detached as they are attached to active instances which is leading to errors. This is a corner case. 

The code changes include proper logging for such a scenario


## For security reasons, all pull requests need to be approved first before running any automated CI
