### PR TITLE
HttpError returned by Google Sheets

### DIFF
--- a/cloud_governance/common/google_drive/google_drive_operations.py
+++ b/cloud_governance/common/google_drive/google_drive_operations.py
@@ -34,7 +34,7 @@ class GoogleDriveOperations:
         """
         try:
             sheet_id = self.find_sheet_id_by_name(sheet_name=sheet_name, spreadsheet_id=gsheet_id)
-            if sheet_id is None:
+            if sheet_id == '':
                 create_worksheet_meta_data = {
                     'requests': [{
                         'addSheet': {
@@ -113,7 +113,7 @@ class GoogleDriveOperations:
                 if 'title' in sheet['properties'].keys():
                     if sheet['properties']['title'] == sheet_name:
                         return sheet['properties']['sheetId']
-        return None
+        return ''
 
     @logger_time_stamp
     def delete_rows(self, spreadsheet_id: str, sheet_name: str, row_number: int):


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Getting a 400 Http Error in Jenkins : 
googleapiclient.errors.HttpError: <HttpError 400 when requesting https://sheets.googleapis.com/v4/spreadsheets/****:batchUpdate?alt=json returned "Invalid requests[0].addSheet: A sheet with the name "PERF-DEPT" already exists. Please enter another name.". Details: "Invalid requests[0].addSheet: A sheet with the name "PERF-DEPT" already exists. Please enter another name.">

PERF-DEPT is the first sheet in the Cloud Tags workbook with id 0, which is causing script to try to create a new worksheet (because of how Python treats the integer 0). 

FIX: Modified the code to handle return value differently, so sheet id 0 does not lead to creating a new sheet (if block).


## For security reasons, all pull requests need to be approved first before running any automated CI
