### PR TITLE
Correct log level from error to info

### DIFF
--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
@@ -172,7 +172,7 @@ def zombie_cluster_resource(delete: bool = False, region: str = 'us-east-2', res
                     es_operations.upload_to_elasticsearch(data=zombie_cluster.copy(), index=es_index)
                     logger.info(f'Uploaded the policy results to elasticsearch index: {es_index}')
         else:
-            logger.error(f'No data to upload on @{account}  at {datetime.utcnow()}')
+            logger.info(f'No data to upload on @{account}  at {datetime.utcnow()}')
     else:
         logger.error('ElasticSearch host is not pingable, Please check ')
     return zombie_result

--- a/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/zombie_non_cluster_polices.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/zombie_non_cluster_polices.py
@@ -40,7 +40,7 @@ class ZombieNonClusterPolicies(NonClusterZombiePolicy):
                                     self._es_operations.upload_to_elasticsearch(data=policy_dict.copy(), index=self._es_index)
                             logger.info(f'Uploaded the policy results to elasticsearch index: {self._es_index}')
                         else:
-                            logger.error(f'No data to upload on @{self._account}  at {datetime.utcnow()}')
+                            logger.info(f'No data to upload on @{self._account}  at {datetime.utcnow()}')
                     else:
                         logger.error('ElasticSearch host is not pingable, Please check ')
 

--- a/cloud_governance/policy/policy_runners/elasticsearch/upload_elastic_search.py
+++ b/cloud_governance/policy/policy_runners/elasticsearch/upload_elastic_search.py
@@ -35,6 +35,6 @@ class UploadElasticSearch(AbstractUpload, ABC):
                             self._es_operations.upload_to_elasticsearch(data=policy_dict.copy(), index=self._es_index)
                     logger.info(f'Uploaded the policy results to elasticsearch index: {self._es_index}')
                 else:
-                    logger.error(f'No data to upload on @{self._account}  at {datetime.utcnow()}')
+                    logger.info(f'No data to upload on @{self._account}  at {datetime.utcnow()}')
             else:
                 logger.error('ElasticSearch host is not pingable, Please check your connection')


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Correct log level from error to info, since the log "No data to upload on @{account}  at {datetime.utcnow()}" does not qualify as an error log.


## For security reasons, all pull requests need to be approved first before running any automated CI
