### PR TITLE
Add new Eco Eng cloud accounts to Jenkins policy runs

### DIFF
--- a/jenkins/tenant/aws/ecoeng_01/PolicyJenkinsfileDaily
+++ b/jenkins/tenant/aws/ecoeng_01/PolicyJenkinsfileDaily
@@ -11,7 +11,13 @@ accounts_list = ['industry-partners': "hhalbfin@redhat.com",
                  'specialprojects-qe': "augol@redhat.com, hhalbfin@redhat.com",
                  'partnerlab': "matt.dorn@redhat.com, jomckenz@redhat.com, babak@redhat.com, hhalbfin@redhat.com, mrhillsman@redhat.com",
                  'blueprints': "abeekhof@redhat.com, hhalbfin@redhat.com",
-                 'coreos-training': "matt.dorn@redhat.com, jomckenz@redhat.com, babak@redhat.com, hhalbfin@redhat.com, mrhillsman@redhat.com"
+                 'coreos-training': "matt.dorn@redhat.com, jomckenz@redhat.com, babak@redhat.com, hhalbfin@redhat.com, mrhillsman@redhat.com",
+                 'edgeinfra-ci': "rfreiman@redhat.com, hhalbfin@redhat.com",
+                 'ecoeng-flightctl': "ayogev@redhat.com, hhalbfin@redhat.com",
+                 'partners-eng': "hhalbfin@redhat.com",
+                 'fusionaccess': "abeekhof@redhat.com,  hhalbfin@redhat.com",
+                 'ecoeng-assistedci': "alkaplan@redhat.com, dmanor@redhat.com, hhalbfin@redhat.com",
+                 'medik8s-ci': "ushkalim@redhat.com,  hhalbfin@redhat.com"
                  ]
 pipeline {
     options {

--- a/jenkins/tenant/aws/ecoeng_01/README.md
+++ b/jenkins/tenant/aws/ecoeng_01/README.md
@@ -1,7 +1,7 @@
 ### ecoeng_01 - dry_run=no
 
 **POLICIES_IN_ACTION
-** = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles"]'
+** = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "zombie_cluster_resource"]'
 
 - Run zombie_cluster_resource in blueprints
 
@@ -18,6 +18,12 @@ Accounts:
 - **verticals-ui**: "brotman@redhat.com, hhalbfin@redhat.com",
 - **special-projects**: "chen.yosef@redhat.com, hhalbfin@redhat.com",
 - **edgeinfra**: "lgamliel@redhat.com, bthurber@redhat.com, oourfali@redhat.com, hhalbfin@redhat.com",
-- **specialprojects-qe**: "augol@redhat.com, hhalbfin@redhat.com"
-- **partnerlab**: "matt.dorn@redhat.com, jomckenz@redhat.com, babak@redhat.com, hhalbfin@redhat.com"
-- **blueprints**: "abeekhof@redhat.com, hhalbfin@redhat.com"
+- **specialprojects-qe**: "augol@redhat.com, hhalbfin@redhat.com",
+- **partnerlab**: "matt.dorn@redhat.com, jomckenz@redhat.com, babak@redhat.com, hhalbfin@redhat.com",
+- **blueprints**: "abeekhof@redhat.com, hhalbfin@redhat.com",
+- **edgeinfra-ci**: "rfreiman@redhat.com, hhalbfin@redhat.com",
+- **ecoeng-flightctl**:  "ayogev@redhat.com, hhalbfin@redhat.com",
+- **partners-eng**: "hhalbfin@redhat.com",
+- **fusionaccess**: "abeekhof@redhat.com,  hhalbfin@redhat.com",
+- **ecoeng-assistedci**: "alkaplan@redhat.com, dmanor@redhat.com, hhalbfin@redhat.com",
+- **medik8s-ci**: "ushkalim@redhat.com,  hhalbfin@redhat.com"

--- a/jenkins/tenant/aws/ecoeng_01/TaggingJenkinsfileHourly
+++ b/jenkins/tenant/aws/ecoeng_01/TaggingJenkinsfileHourly
@@ -1,6 +1,7 @@
 account = ['industry-partners', 'verticals-ui', 'special-projects', 'edgeinfra', 'specialprojects-qe',
            'ecoeng-sap', 'sysdeseng', 'certification-pipeline', 'ecoengverticals-qe',
-           'emerge-partner', 'telco5g-ci', 'partnerlab', 'blueprints']
+           'emerge-partner', 'telco5g-ci', 'partnerlab', 'blueprints', 'edgeinfra-ci',
+           'ecoeng-flightctl', 'partners-eng', 'fusionaccess', 'ecoeng-assistedci', 'medik8s-ci']
 pipeline {
     options {
         disableConcurrentBuilds()


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [x] documentation
- [ ] dependencies

## Description
Add new eco eng cloud accounts to Jenkins policy runs. 
Pre-requisites:

1. Added new credentials in Jenkins under haim folder.
2. Created S3 bucket in 'us-east-1' for all new accounts. 

## For security reasons, all pull requests need to be approved first before running any automated CI
