### PR TITLE
Fix send_aggregated_alerts email alerts

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -30,6 +30,8 @@ jobs:
           sudo apt update -y
           sudo apt-get install build-essential python3-dev libldap2-dev libsasl2-dev vim -y
           python -m pip install --upgrade pip
+          pip install "setuptools<82"
+          pip install --no-build-isolation ibm-cloud-sdk-core==3.18.0 ibm-platform-services==0.27.0 ibm-vpc==0.21.0
           pip install flake8 pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f tests_requirements.txt ]; then pip install -r tests_requirements.txt; fi
@@ -145,6 +147,8 @@ jobs:
           sudo apt update -y
           sudo apt-get install build-essential python3-dev libldap2-dev libsasl2-dev vim -y
           python -m pip install --upgrade pip
+          pip install "setuptools<82"
+          pip install --no-build-isolation ibm-cloud-sdk-core==3.18.0 ibm-platform-services==0.27.0 ibm-vpc==0.21.0
           pip install flake8 pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f tests_requirements.txt ]; then pip install -r tests_requirements.txt; fi

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -130,6 +130,8 @@ jobs:
           sudo apt update -y
           sudo apt-get install -y build-essential python3-dev libldap2-dev libsasl2-dev
           python -m pip install --upgrade pip
+          pip install "setuptools<82"
+          pip install --no-build-isolation ibm-cloud-sdk-core==3.18.0 ibm-platform-services==0.27.0 ibm-vpc==0.21.0
           pip install pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f tests_requirements.txt ]; then pip install -r tests_requirements.txt; fi
@@ -232,6 +234,8 @@ jobs:
           sudo apt update -y
           sudo apt-get install -y build-essential python3-dev libldap2-dev libsasl2-dev
           python -m pip install --upgrade pip
+          pip install "setuptools<82"
+          pip install --no-build-isolation ibm-cloud-sdk-core==3.18.0 ibm-platform-services==0.27.0 ibm-vpc==0.21.0
           pip install pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f tests_requirements.txt ]; then pip install -r tests_requirements.txt; fi

--- a/.github/workflows/PR_Approval.yml
+++ b/.github/workflows/PR_Approval.yml
@@ -30,6 +30,8 @@ jobs:
           sudo apt update -y
           sudo apt-get install -y build-essential python3-dev libldap2-dev libsasl2-dev
           python -m pip install --upgrade pip
+          pip install "setuptools<82"
+          pip install --no-build-isolation ibm-cloud-sdk-core==3.18.0 ibm-platform-services==0.27.0 ibm-vpc==0.21.0
           pip install flake8 pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f tests_requirements.txt ]; then pip install -r tests_requirements.txt; fi

--- a/cloud_governance/policy/common_policies/send_aggregated_alerts.py
+++ b/cloud_governance/policy/common_policies/send_aggregated_alerts.py
@@ -86,8 +86,11 @@ class SendAggregatedAlerts:
         """
         if policy_es_data:
             df = pandas.DataFrame(policy_es_data)
-            df.sort_values(inplace=True, by=['policy'])
-            df.fillna(value='', inplace=True)
+            policy_col = 'policy' if 'policy' in df.columns else 'Policy'
+            sort_col = policy_col if policy_col in df.columns else df.columns[0]
+            df.sort_values(inplace=True, by=[sort_col])
+            # Avoid fillna(value='') on numeric columns (pandas 2.x+ raises LossySetitemError)
+            df = df.astype(object).fillna('')
             df.drop_duplicates(subset='ResourceId', inplace=True)
             return df.to_dict(orient="records")
         return policy_es_data

--- a/jenkins/clouds/aws/daily/policies/run_policies.py
+++ b/jenkins/clouds/aws/daily/policies/run_policies.py
@@ -21,7 +21,7 @@ GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
 ADMIN_MAIL_LIST = os.environ.get('ADMIN_MAIL_LIST', '')
 # QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ.get('QUAY_CLOUD_GOVERNANCE_REPOSITORY',
 #                                                   'quay.io/cloud-governance/cloud-governance:latest')
-QUAY_CLOUD_GOVERNANCE_REPOSITORY = 'quay.io/cloud-governance/rh-ee-pragchau:latest'
+QUAY_CLOUD_GOVERNANCE_REPOSITORY = 'quay.io/rh-ee-pragchau/cloud-governance:latest'
 
 
 def get_policies(file_type: str = '.py', exclude_policies: list = None):

--- a/jenkins/clouds/aws/daily/policies/run_policies.py
+++ b/jenkins/clouds/aws/daily/policies/run_policies.py
@@ -19,8 +19,9 @@ GOOGLE_APPLICATION_CREDENTIALS = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
 SPREADSHEET_ID = os.environ['AWS_IAM_USER_SPREADSHEET_ID']
 GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
 ADMIN_MAIL_LIST = os.environ.get('ADMIN_MAIL_LIST', '')
-QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ.get('QUAY_CLOUD_GOVERNANCE_REPOSITORY',
-                                                  'quay.io/cloud-governance/cloud-governance:latest')
+# QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ.get('QUAY_CLOUD_GOVERNANCE_REPOSITORY',
+#                                                   'quay.io/cloud-governance/cloud-governance:latest')
+QUAY_CLOUD_GOVERNANCE_REPOSITORY = 'quay.io/cloud-governance/rh-ee-pragchau:latest'
 
 
 def get_policies(file_type: str = '.py', exclude_policies: list = None):

--- a/jenkins/clouds/aws/daily/policies/run_policies.py
+++ b/jenkins/clouds/aws/daily/policies/run_policies.py
@@ -115,26 +115,26 @@ def run_policies(policies: list, dry_run: str = 'yes'):
 
 # Running the polices in dry_run=yes
 
-run_cmd(f"echo Running the cloud_governance policies with dry_run=yes")
-run_cmd(f"echo Polices list: {policies_not_action}")
-run_policies(policies=policies_not_action)
+# run_cmd(f"echo Running the cloud_governance policies with dry_run=yes")
+# run_cmd(f"echo Polices list: {policies_not_action}")
+# run_policies(policies=policies_not_action)
 
-# Running the polices in dry_run=no
+# # Running the polices in dry_run=no
 
-run_cmd('echo "Running the CloudGovernance policies with dry_run=no" ')
-run_cmd(f"echo Polices list: {policies_in_action}")
-run_policies(policies=policies_in_action, dry_run='no')
+# run_cmd('echo "Running the CloudGovernance policies with dry_run=no" ')
+# run_cmd(f"echo Polices list: {policies_in_action}")
+# run_policies(policies=policies_in_action, dry_run='no')
 
-# Update AWS IAM User tags from the spreadsheet
+# # Update AWS IAM User tags from the spreadsheet
 
-run_cmd(f"""echo "Running the tag_iam_user" """)
-run_cmd(
-    f"""podman run --rm --name cloud-governance --net="host" -e account="{account_name}" -e EMAIL_ALERT="False" -e policy="tag_iam_user" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e user_tag_operation="update" -e SPREADSHEET_ID="{SPREADSHEET_ID}" -e GOOGLE_APPLICATION_CREDENTIALS="{GOOGLE_APPLICATION_CREDENTIALS}" -v "{GOOGLE_APPLICATION_CREDENTIALS}":"{GOOGLE_APPLICATION_CREDENTIALS}" -e LDAP_HOST_NAME="{LDAP_HOST_NAME}" -e account_admin="{account_admin}" -e special_user_mails="{special_user_mails}"  -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+# run_cmd(f"""echo "Running the tag_iam_user" """)
+# run_cmd(
+#     f"""podman run --rm --name cloud-governance --net="host" -e account="{account_name}" -e EMAIL_ALERT="False" -e policy="tag_iam_user" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e user_tag_operation="update" -e SPREADSHEET_ID="{SPREADSHEET_ID}" -e GOOGLE_APPLICATION_CREDENTIALS="{GOOGLE_APPLICATION_CREDENTIALS}" -v "{GOOGLE_APPLICATION_CREDENTIALS}":"{GOOGLE_APPLICATION_CREDENTIALS}" -e LDAP_HOST_NAME="{LDAP_HOST_NAME}" -e account_admin="{account_admin}" -e special_user_mails="{special_user_mails}"  -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
 
-# Running the trust advisor reports, data dumped into default index - cloud-governance-policy-es-index
+# # Running the trust advisor reports, data dumped into default index - cloud-governance-policy-es-index
 
-run_cmd(
-    f"""podman run --rm --net="host" --name cloud-governance -e AWS_DEFAULT_REGION="us-east-1" -e account="{account_name}" -e policy="optimize_resources_report" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}"  -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+# run_cmd(
+#     f"""podman run --rm --net="host" --name cloud-governance -e AWS_DEFAULT_REGION="us-east-1" -e account="{account_name}" -e policy="optimize_resources_report" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}"  -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
 
 # Git-leaks run on GitHub not related to any aws account
 # run_cmd("echo Run Git-leaks")

--- a/jenkins/clouds/aws/daily/policies/run_policies.py
+++ b/jenkins/clouds/aws/daily/policies/run_policies.py
@@ -19,9 +19,8 @@ GOOGLE_APPLICATION_CREDENTIALS = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
 SPREADSHEET_ID = os.environ['AWS_IAM_USER_SPREADSHEET_ID']
 GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
 ADMIN_MAIL_LIST = os.environ.get('ADMIN_MAIL_LIST', '')
-# QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ.get('QUAY_CLOUD_GOVERNANCE_REPOSITORY',
-#                                                   'quay.io/cloud-governance/cloud-governance:latest')
-QUAY_CLOUD_GOVERNANCE_REPOSITORY = 'quay.io/rh-ee-pragchau/cloud-governance:latest'
+QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ.get('QUAY_CLOUD_GOVERNANCE_REPOSITORY',
+                                                  'quay.io/cloud-governance/cloud-governance:latest')
 
 
 def get_policies(file_type: str = '.py', exclude_policies: list = None):
@@ -116,30 +115,30 @@ def run_policies(policies: list, dry_run: str = 'yes'):
 
 # Running the polices in dry_run=yes
 
-# run_cmd(f"echo Running the cloud_governance policies with dry_run=yes")
-# run_cmd(f"echo Polices list: {policies_not_action}")
-# run_policies(policies=policies_not_action)
+run_cmd(f"echo Running the cloud_governance policies with dry_run=yes")
+run_cmd(f"echo Polices list: {policies_not_action}")
+run_policies(policies=policies_not_action)
 
-# # Running the polices in dry_run=no
+# Running the polices in dry_run=no
 
-# run_cmd('echo "Running the CloudGovernance policies with dry_run=no" ')
-# run_cmd(f"echo Polices list: {policies_in_action}")
-# run_policies(policies=policies_in_action, dry_run='no')
+run_cmd('echo "Running the CloudGovernance policies with dry_run=no" ')
+run_cmd(f"echo Polices list: {policies_in_action}")
+run_policies(policies=policies_in_action, dry_run='no')
 
-# # Update AWS IAM User tags from the spreadsheet
+# Update AWS IAM User tags from the spreadsheet
 
-# run_cmd(f"""echo "Running the tag_iam_user" """)
-# run_cmd(
-#     f"""podman run --rm --name cloud-governance --net="host" -e account="{account_name}" -e EMAIL_ALERT="False" -e policy="tag_iam_user" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e user_tag_operation="update" -e SPREADSHEET_ID="{SPREADSHEET_ID}" -e GOOGLE_APPLICATION_CREDENTIALS="{GOOGLE_APPLICATION_CREDENTIALS}" -v "{GOOGLE_APPLICATION_CREDENTIALS}":"{GOOGLE_APPLICATION_CREDENTIALS}" -e LDAP_HOST_NAME="{LDAP_HOST_NAME}" -e account_admin="{account_admin}" -e special_user_mails="{special_user_mails}"  -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+run_cmd(f"""echo "Running the tag_iam_user" """)
+run_cmd(
+    f"""podman run --rm --name cloud-governance --net="host" -e account="{account_name}" -e EMAIL_ALERT="False" -e policy="tag_iam_user" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e user_tag_operation="update" -e SPREADSHEET_ID="{SPREADSHEET_ID}" -e GOOGLE_APPLICATION_CREDENTIALS="{GOOGLE_APPLICATION_CREDENTIALS}" -v "{GOOGLE_APPLICATION_CREDENTIALS}":"{GOOGLE_APPLICATION_CREDENTIALS}" -e LDAP_HOST_NAME="{LDAP_HOST_NAME}" -e account_admin="{account_admin}" -e special_user_mails="{special_user_mails}"  -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
 
-# # Running the trust advisor reports, data dumped into default index - cloud-governance-policy-es-index
+# Running the trust advisor reports, data dumped into default index - cloud-governance-policy-es-index
 
-# run_cmd(
-#     f"""podman run --rm --net="host" --name cloud-governance -e AWS_DEFAULT_REGION="us-east-1" -e account="{account_name}" -e policy="optimize_resources_report" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}"  -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+run_cmd(
+    f"""podman run --rm --net="host" --name cloud-governance -e AWS_DEFAULT_REGION="us-east-1" -e account="{account_name}" -e policy="optimize_resources_report" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}"  -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
 
 # Git-leaks run on GitHub not related to any aws account
 # run_cmd("echo Run Git-leaks")
-#
+
 # region = 'us-east-1'
 # policy = 'gitleaks'
 # run_cmd(

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ google-cloud-billing==1.9.1
 ibm-cloud-sdk-core==3.18.0
 ibm-cos-sdk==2.13.6
 ibm-platform-services==0.27.0
-ibm-schematics==1.1.0
+ibm-schematics==1.0.1
 ibm-vpc==0.21.0
 myst-parser==1.0.0
 numpy<=1.26.4 # opensearch 1.2.4 for elasticsearch

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     author_email='ebattat@redhat.com, pragchau@redhat.com',
     url='https://github.com/redhat-performance/cloud-governance',
     license="Apache License 2.0",
+    python_requires='>=3.9',
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',
@@ -60,7 +61,7 @@ setup(
         'ibm-cloud-sdk-core==3.18.0',
         'ibm-cos-sdk==2.13.6',
         'ibm-platform-services==0.27.0',  # IBM Usage reports
-        'ibm-schematics==1.1.0',
+        'ibm-schematics==1.0.1',
         'ibm-vpc==0.21.0',
         'myst-parser==1.0.0',  # readthedocs
         'numpy<=1.26.4',  # opensearch 1.2.4 for elasticsearch

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -10,7 +10,7 @@ elasticsearch-dsl==7.4.0
 freezegun==1.5.1
 ibm-cloud-sdk-core==3.18.0
 ibm-platform-services==0.27.0
-ibm-schematics==1.1.0
+ibm-schematics==1.0.1
 ibm-vpc==0.21.0
 moto==4.0.1
 numpy<=1.26.4


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
The PR includes the fix for the traceback found while running policy send_aggregated_alerts in daily Jenkins policies run. 

The DataFrame is built from Elasticsearch data that includes numeric fields (e.g. counts, days). Pandas infers columns like those as float64. In newer pandas (and with Python 3.13), fillna(value='') is no longer allowed on numeric dtypes because:
1. Putting the string '' into a float64 column would require changing the column type.
2. Pandas treats that as a lossy/invalid operation and raises:
 pandas.errors.LossySetitemError, then
 TypeError: Invalid value '' for dtype 'float64'.

## For security reasons, all pull requests need to be approved first before running any automated CI
