### PR TITLE
Fix deprecated utcnow datetime warnings

### DIFF
--- a/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/aws_monitor_tickets.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/aws_monitor_tickets.py
@@ -1,6 +1,6 @@
 import json
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 
 import typeguard
 
@@ -232,7 +232,7 @@ class AWSMonitorTickets(AbstractMonitorTickets):
                         self.__es_operations.update_elasticsearch_index(index=self.es_cro_index, id=ticket_id,
                                                                         metadata={
                                                                             'cluster_cost': cluster_cost,
-                                                                            'timestamp': datetime.utcnow()
+                                                                            'timestamp': datetime.now(tz=timezone.utc)
                                                                         })
 
     def __prepare_athena_query_for_cluster_cost(self, names: list):

--- a/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/collect_cro_reports.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/collect_cro_reports.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import typeguard
 
@@ -45,7 +45,7 @@ class CollectCROReports:
                     "must": [
                         {"term": {"CloudName.keyword": self.__public_cloud_name}},
                         {"term": {"AccountId.keyword": self.__account_id}},
-                        {"term": {"Month": str(datetime.utcnow().year)}},
+                        {"term": {"Month": str(datetime.now(tz=timezone.utc).year)}},
                     ]
                 }
             },
@@ -61,7 +61,7 @@ class CollectCROReports:
         This method returns the total account budget till date for this year
         :return:
         """
-        current_date = datetime.utcnow().date()
+        current_date = datetime.now(tz=timezone.utc).date()
         start_date = datetime(current_date.year, 1, 1).date()
         cost_explorer_operations = self.__cost_over_usage.get_cost_explorer_operations()
         response = cost_explorer_operations.get_cost_and_usage_from_aws(start_date=str(start_date), end_date=str(current_date+timedelta(days=1)), granularity='MONTHLY')
@@ -92,7 +92,7 @@ class CollectCROReports:
             return_key = 'Forecast'
         else:
             response = self.__cost_over_usage.get_monthly_user_es_cost_data(start_date=start_date,
-                                                                            end_date=datetime.utcnow().replace(microsecond=self.ZERO) + timedelta(days=1),
+                                                                            end_date=datetime.now(tz=timezone.utc).replace(microsecond=self.ZERO) + timedelta(days=1),
                                                                             extra_matches=extra_filter_matches, extra_operation=self.AND, tag_name=group_by_tag_name)
             return_key = 'Cost'
         if response:
@@ -173,7 +173,7 @@ class CollectCROReports:
             source['user_cro'] = instance_data[self.ZERO].get('user_cro')
         if instance_data[self.ZERO].get('user') and source.get('user') != instance_data[self.ZERO].get('user'):
             source['user'] = instance_data[self.ZERO].get('user')
-        source['timestamp'] = datetime.utcnow()
+        source['timestamp'] = datetime.now(tz=timezone.utc)
         if source.get('ticket_id_state') != 'in-progress':
             source['ticket_id_state'] = 'in-progress'
             source['approved_manager'] = instance_data[self.ZERO].get('approved_manager')
@@ -213,7 +213,7 @@ class CollectCROReports:
             user_cost = self.get_user_cost_data(group_by_tag_name=group_by_tag_name, group_by_tag_value=ticket_id,
                                                 requested_date=ticket_opened_date)
             duration = int(instance_data[self.ZERO].get('duration', 0))
-            user_forecast = self.get_user_cost_data(group_by_tag_name=group_by_tag_name, group_by_tag_value=ticket_id, requested_date=datetime.utcnow(), extra_filter_key_values={'Project': user_project}, forecast=True, duration=duration)
+            user_forecast = self.get_user_cost_data(group_by_tag_name=group_by_tag_name, group_by_tag_value=ticket_id, requested_date=datetime.now(tz=timezone.utc), extra_filter_key_values={'Project': user_project}, forecast=True, duration=duration)
             cost_estimation = float(instance_data[self.ZERO].get('estimated_cost', self.ZERO))
             if self.__cost_over_usage.es_operations.verify_elastic_index_doc_id(index=self.__cost_over_usage.es_index_cro, doc_id=ticket_id):
                 es_data = self.__cost_over_usage.es_operations.get_es_data_by_id(id=ticket_id,index=self.__cost_over_usage.es_index_cro)
@@ -270,10 +270,10 @@ class CollectCROReports:
                                                                           user_name=user_name)
                 user_daily_cost.update(ce_user_daily_report)
                 user_forecast = self.get_user_cost_data(group_by_tag_name=group_by_tag_name,
-                                                        group_by_tag_value=ticket_id, requested_date=datetime.utcnow(),
+                                                        group_by_tag_value=ticket_id, requested_date=datetime.now(tz=timezone.utc),
                                                         forecast=True, duration=duration)
-                update_data = {'actual_cost': user_cost, 'forecast': user_forecast, 'timestamp': datetime.utcnow(),
-                               f'TotalCurrentUsage-{datetime.utcnow().year}': total_account_cost,
+                update_data = {'actual_cost': user_cost, 'forecast': user_forecast, 'timestamp': datetime.now(tz=timezone.utc),
+                               f'TotalCurrentUsage-{datetime.now(tz=timezone.utc).year}': total_account_cost,
                                'user_daily_cost': str(user_daily_cost)}
                 if not source_data.get(self.ALLOCATED_BUDGET):
                     update_data[self.ALLOCATED_BUDGET] = self.get_account_budget_from_payer_ce_report()
@@ -302,7 +302,7 @@ class CollectCROReports:
         :param tag_value:
         :return:
         """
-        end_date = datetime.utcnow().date()
+        end_date = datetime.now(tz=timezone.utc).date()
         start_date = end_date - timedelta(days=days)
         cost_explorer_object = self.__cost_over_usage.get_cost_explorer_operations()
         ce_daily_usage = cost_explorer_object.get_cost_by_tags(tag=tag_name,

--- a/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/cost_over_usage.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/cost_over_usage.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from ast import literal_eval
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import typeguard
 
@@ -45,7 +45,7 @@ class CostOverUsage:
         self.__cro_admins = self.__environment_variables_dict.get('CRO_DEFAULT_ADMINS', [])
         self.es_index_cro = self.__environment_variables_dict.get('CRO_ES_INDEX', '')
         self.__cro_duration_days = self.__environment_variables_dict.get('CRO_DURATION_DAYS')
-        self.current_end_date = datetime.utcnow()
+        self.current_end_date = datetime.now(tz=timezone.utc)
         self.current_start_date = self.current_end_date - timedelta(days=self.__cro_duration_days)
         self.__public_cloud_name = self.__environment_variables_dict.get('PUBLIC_CLOUD_NAME')
         self.__ce_operations = CostExplorerOperations()
@@ -293,7 +293,7 @@ class CostOverUsage:
             last_alert = response[0]
             last_send_date = last_alert.get('_source').get('timestamp')
             alert_number = last_alert.get('_source').get('Alert', 0)
-            current_date = datetime.utcnow().date()
+            current_date = datetime.now(tz=timezone.utc).date()
             last_send_date = datetime.strptime(last_send_date, self.TIMESTAMP_DATE_FORMAT).date()
             days = (current_date - last_send_date).days
             if days % self.SEND_ALERT_DAY == 0 and last_send_date != current_date:

--- a/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/run_cro.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/run_cro.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import boto3
 
@@ -14,7 +14,7 @@ from cloud_governance.main.environment_variables import environment_variables
 
 class RunCRO:
 
-    PERSISTENT_RUN_DOC_ID = f'cro_run_persistence-{datetime.utcnow().date()}'
+    PERSISTENT_RUN_DOC_ID = f'cro_run_persistence-{datetime.now(tz=timezone.utc).date()}'
     PERSISTENT_RUN_INDEX = 'cloud_resource_orchestration_persistence_run'
 
     def __init__(self):
@@ -39,7 +39,7 @@ class RunCRO:
             last_run_time = source.get(f'last_run_{self.account.lower()}')
             if last_run_time:
                 last_updated_time = datetime.strptime(last_run_time, "%Y-%m-%dT%H:%M:%S.%f").date()
-                if last_updated_time == datetime.utcnow().date():
+                if last_updated_time == datetime.now(tz=timezone.utc).date():
                     first_run = False
         self.__environment_variables_dict.update({'CRO_FIRST_RUN': first_run})
         if first_run:
@@ -57,9 +57,9 @@ class RunCRO:
         :return:
         """
         if not self.cro_cost_over_usage.es_operations.verify_elastic_index_doc_id(index=self.PERSISTENT_RUN_INDEX, doc_id=self.PERSISTENT_RUN_DOC_ID):
-            self.cro_cost_over_usage.es_operations.upload_to_elasticsearch(index=self.PERSISTENT_RUN_INDEX, data={f'last_run_{self.account}': datetime.utcnow()}, id=self.PERSISTENT_RUN_DOC_ID)
+            self.cro_cost_over_usage.es_operations.upload_to_elasticsearch(index=self.PERSISTENT_RUN_INDEX, data={f'last_run_{self.account}': datetime.now(tz=timezone.utc)}, id=self.PERSISTENT_RUN_DOC_ID)
         else:
-            self.cro_cost_over_usage.es_operations.update_elasticsearch_index(index=self.PERSISTENT_RUN_INDEX, metadata={f'last_run_{self.account}': datetime.utcnow()}, id=self.PERSISTENT_RUN_DOC_ID)
+            self.cro_cost_over_usage.es_operations.update_elasticsearch_index(index=self.PERSISTENT_RUN_INDEX, metadata={f'last_run_{self.account}': datetime.now(tz=timezone.utc)}, id=self.PERSISTENT_RUN_DOC_ID)
 
     @logger_time_stamp
     def run_cloud_resources(self):

--- a/cloud_governance/cloud_resource_orchestration/clouds/azure/resource_groups/collect_cro_reports.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/azure/resource_groups/collect_cro_reports.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import typeguard
 
@@ -33,7 +33,7 @@ class CollectCROReports(AbstractCollectCROReports):
                     "must": [
                         {"term": {"CloudName.keyword": self._public_cloud_name}},
                         {"term": {"AccountId.keyword": self._account_id}},
-                        {"term": {"Month": str(datetime.utcnow().year)}},
+                        {"term": {"Month": str(datetime.now(tz=timezone.utc).year)}},
                     ]
                 }
             },
@@ -69,7 +69,7 @@ class CollectCROReports(AbstractCollectCROReports):
             resource_type = 'Forecast'
             pass
         else:
-            end_date = datetime.utcnow().replace(microsecond=self.ZERO) + timedelta(days=1)
+            end_date = datetime.now(tz=timezone.utc).replace(microsecond=self.ZERO) + timedelta(days=1)
             response = self.__cost_over_usage.get_monthly_user_es_cost_data(start_date=start_date, end_date=end_date,
                                                                             extra_matches=extra_filter_matches,
                                                                             extra_operation=self.AND,
@@ -124,7 +124,7 @@ class CollectCROReports(AbstractCollectCROReports):
         This method returns the total account budget till date for this year
         :return:
         """
-        current_date = datetime.utcnow()
+        current_date = datetime.now(tz=timezone.utc)
         start_date = datetime(current_date.year, 1, 1, 0, 0, 0)
         end_date = current_date + timedelta(days=1)
         cost_explorer_operations = self.__cost_over_usage.get_cost_management_object()
@@ -163,8 +163,8 @@ class CollectCROReports(AbstractCollectCROReports):
                                                                           group_by_tag_name=group_by_tag_name,
                                                                           user_name=user_name)
                 user_daily_cost.update(ce_user_daily_report)
-                update_data = {'actual_cost': user_cost, 'timestamp': datetime.utcnow(),
-                               f'TotalCurrentUsage-{datetime.utcnow().year}': total_account_cost,
+                update_data = {'actual_cost': user_cost, 'timestamp': datetime.now(tz=timezone.utc),
+                               f'TotalCurrentUsage-{datetime.now(tz=timezone.utc).year}': total_account_cost,
                                'user_daily_cost': str(user_daily_cost)}
                 if not source_data.get(self.ALLOCATED_BUDGET):
                     update_data[self.ALLOCATED_BUDGET] = self._get_account_budget_from_payer_ce_report()
@@ -192,7 +192,7 @@ class CollectCROReports(AbstractCollectCROReports):
         :param tag_value:
         :return:
         """
-        end_date = datetime.utcnow()
+        end_date = datetime.now(tz=timezone.utc)
         start_date = end_date - timedelta(days=days)
         cost_explorer_object = self.__cost_over_usage.get_cost_management_object()
         ce_daily_usage = cost_explorer_object.get_usage(scope=self.__scope, grouping=[tag_name], granularity='Daily',

--- a/cloud_governance/cloud_resource_orchestration/clouds/common/abstract_collect_cro_reports.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/common/abstract_collect_cro_reports.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import typeguard
 
@@ -116,7 +116,7 @@ class AbstractCollectCROReports(ABC):
             source['user_cro'] = instance_data[self.ZERO].get('user_cro')
         if instance_data[self.ZERO].get('user') and source.get('user') != instance_data[self.ZERO].get('user'):
             source['user'] = instance_data[self.ZERO].get('user')
-        source['timestamp'] = datetime.utcnow()
+        source['timestamp'] = datetime.now(tz=timezone.utc)
         if source.get('ticket_id_state') != 'in-progress':
             source['ticket_id_state'] = 'in-progress'
             source['approved_manager'] = instance_data[self.ZERO].get('approved_manager')

--- a/cloud_governance/cloud_resource_orchestration/clouds/common/abstract_cost_over_usage.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/common/abstract_cost_over_usage.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from ast import literal_eval
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import typeguard
 
@@ -35,7 +35,7 @@ class AbstractCostOverUsage(ABC):
         self.es_index_cro = self._environment_variables_dict.get('CRO_ES_INDEX', '')
         self._cro_duration_days = self._environment_variables_dict.get('CRO_DURATION_DAYS')
         self._over_usage_threshold = OVER_USAGE_THRESHOLD * self._over_usage_amount
-        self.current_end_date = datetime.utcnow()
+        self.current_end_date = datetime.now(tz=timezone.utc)
         self.current_start_date = self.current_end_date - timedelta(days=self._cro_duration_days)
         self.es_operations = ElasticSearchOperations(es_host=self._es_host, es_port=self._es_port)
         self._elastic_search_queries = ElasticSearchQueries(cro_duration_days=self._cro_duration_days)

--- a/cloud_governance/cloud_resource_orchestration/common/run_cro.py
+++ b/cloud_governance/cloud_resource_orchestration/common/run_cro.py
@@ -34,7 +34,7 @@ class RunCRO:
         if not self.__es_operations.verify_elastic_index_doc_id(index=self.PERSISTENT_RUN_INDEX,
                                                                 doc_id=self.PERSISTENT_RUN_DOC_ID):
             self.__es_operations.upload_to_elasticsearch(index=self.PERSISTENT_RUN_INDEX, data={
-                f'last_run_{self.__account.lower()}': datetime.utcnow()}, id=self.PERSISTENT_RUN_DOC_ID)
+                f'last_run_{self.__account.lower()}': datetime.now(tz=timezone.utc)}, id=self.PERSISTENT_RUN_DOC_ID)
         else:
             self.__es_operations.update_elasticsearch_index(index=self.PERSISTENT_RUN_INDEX,
                                                             metadata={
@@ -56,7 +56,7 @@ class RunCRO:
                 last_run_time = source.get(f'last_run_{self.__account.lower()}')
                 if last_run_time:
                     last_updated_time = datetime.strptime(last_run_time, "%Y-%m-%dT%H:%M:%S.%f").date()
-                    if last_updated_time == datetime.utcnow().date():
+                    if last_updated_time == datetime.now(tz=timezone.utc).date():
                         first_run = False
             self.__environment_variables_dict.update({'CRO_FIRST_RUN': first_run})
             if first_run:

--- a/cloud_governance/cloud_resource_orchestration/utils/elastic_search_queries.py
+++ b/cloud_governance/cloud_resource_orchestration/utils/elastic_search_queries.py
@@ -1,5 +1,5 @@
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 class ElasticSearchQueries:
@@ -8,7 +8,7 @@ class ElasticSearchQueries:
     """
 
     def __init__(self, cro_duration_days: int = 30):
-        self.current_end_date = datetime.utcnow()
+        self.current_end_date = datetime.now(tz=timezone.utc)
         self.current_start_date = self.current_end_date - timedelta(days=cro_duration_days)
 
     def get_all_in_progress_tickets(self, match_conditions: list = None, fields: list = None,  **kwargs):

--- a/cloud_governance/common/clouds/aws/athena/abstract_athena_operations.py
+++ b/cloud_governance/common/clouds/aws/athena/abstract_athena_operations.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 
 from cloud_governance.main.environment_variables import environment_variables
 
 
 class AbstractAthenaOperations(ABC):
 
-    CURRENT_DATE = str(datetime.utcnow().date()).replace("-", "")
+    CURRENT_DATE = str(datetime.now(tz=timezone.utc).date()).replace("-", "")
 
     def __init__(self):
         self.__environment_variables_dict = environment_variables.environment_variables_dict

--- a/cloud_governance/common/clouds/azure/monitor/monitor_management_operations.py
+++ b/cloud_governance/common/clouds/azure/monitor/monitor_management_operations.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from azure.core.exceptions import HttpResponseError
 from azure.mgmt.monitor import MonitorManagementClient
@@ -22,7 +22,7 @@ class MonitorManagementOperations(CommonOperations):
         :return:
         :rtype:
         """
-        return datetime.utcnow()
+        return datetime.now(tz=timezone.utc)
 
     def __get_start_date(self):
         """
@@ -79,7 +79,7 @@ class MonitorManagementOperations(CommonOperations):
         :rtype:
         """
         if not timespan:
-            end_date = datetime.utcnow()
+            end_date = datetime.now(tz=timezone.utc)
             start_date = end_date - timedelta(days=UNUSED_DAYS)
             timespan = f'{start_date}/{end_date}'
         response = self.__monitor_client.metrics.list(resource_uri=resource_id, timespan=timespan,

--- a/cloud_governance/common/elasticsearch/elasticsearch_operations.py
+++ b/cloud_governance/common/elasticsearch/elasticsearch_operations.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 import pandas as pd
 from elasticsearch.helpers import bulk
@@ -154,7 +154,7 @@ class ElasticSearchOperations:
 
         # utcnow - solve timestamp issue
         if not data.get('timestamp'):
-            data['timestamp'] = datetime.utcnow()  # datetime.now()
+            data['timestamp'] = datetime.now(tz=timezone.utc)  # datetime.now()
         if 'policy' not in data:
             data['policy'] = self.__environment_variables_dict.get('policy')
         # Upload data to elastic search server
@@ -345,7 +345,7 @@ class ElasticSearchOperations:
                     if 'CurrentDate' in item:
                         item['timestamp'] = datetime.strptime(item.get('CurrentDate'), "%Y-%m-%d")
                     else:
-                        item['timestamp'] = datetime.utcnow()
+                        item['timestamp'] = datetime.now(tz=timezone.utc)
                 item['_index'] = index
                 if item.get('AccountId'):
                     item['AccountId'] = str(item.get('AccountId'))

--- a/cloud_governance/common/utils/utils.py
+++ b/cloud_governance/common/utils/utils.py
@@ -1,6 +1,6 @@
 
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Union
 import re
 
@@ -128,7 +128,7 @@ class Utils:
         :rtype:
         """
         days = 1 if days == 0 else days
-        end_date = datetime.utcnow()
+        end_date = datetime.now(tz=timezone.utc)
         start_date = end_date - timedelta(days=days)
         return start_date, end_date
 

--- a/cloud_governance/main/es_uploader.py
+++ b/cloud_governance/main/es_uploader.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 import pandas as pd
 
 from cloud_governance.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
@@ -190,7 +190,7 @@ class ESUploader:
             data[key] = value
 
         # utcnow - solve timestamp issue
-        data['timestamp'] = datetime.utcnow()  # datetime.now()
+        data['timestamp'] = datetime.now(tz=timezone.utc)  # datetime.now()
 
         # Upload data to elastic search server
         try:

--- a/cloud_governance/policy/aws/cleanup/instance_run.py
+++ b/cloud_governance/policy/aws/cleanup/instance_run.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from cloud_governance.policy.helpers.aws.aws_policy_operations import AWSPolicyOperations
 
@@ -18,7 +18,7 @@ class InstanceRun(AWSPolicyOperations):
         """
         instance_types = self._update_instance_type_count()
         account = self.account
-        current_day = datetime.utcnow()
+        current_day = datetime.now(tz=timezone.utc)
         es_instance_types_data = []
         for region, instance_types in instance_types.items():
             for instance_type, instance_type_count in instance_types.items():

--- a/cloud_governance/policy/aws/cleanup/unused_nat_gateway.py
+++ b/cloud_governance/policy/aws/cleanup/unused_nat_gateway.py
@@ -27,7 +27,7 @@ class UnUsedNatGateway(AWSPolicyOperations):
         """
         if days == 0:
             days = 1
-        end_time = datetime.datetime.utcnow()
+        end_time = datetime.datetime.now(tz=datetime.timezone.utc)
         start_time = end_time - datetime.timedelta(days=days)
         response = self._cloudwatch.get_metric_data(start_time=start_time, end_time=end_time, resource_id=resource_id,
                                                     resource_type='NatGatewayId', namespace=self.NAMESPACE,

--- a/cloud_governance/policy/aws/cost_explorer_payer_billings.py
+++ b/cloud_governance/policy/aws/cost_explorer_payer_billings.py
@@ -238,7 +238,7 @@ class CostExplorerPayerBillings(CostBillingReports):
 
     def get_monthly_cost_details(self, start_date: datetime = None, end_date: datetime = None):
         """This method list the savings plan details"""
-        current_date = datetime.datetime.utcnow()
+        current_date = datetime.datetime.now(tz=datetime.timezone.utc)
         if not start_date and not end_date:
             end_date = (current_date.replace(day=1) - datetime.timedelta(days=1)).date()
             start_date = end_date.replace(day=1)

--- a/cloud_governance/policy/aws/spot_savings_analysis.py
+++ b/cloud_governance/policy/aws/spot_savings_analysis.py
@@ -1,5 +1,5 @@
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import typeguard
 
@@ -32,7 +32,7 @@ class SpotSavingsAnalysis:
         This method prepare the query
         :return:
         """
-        current_date = datetime.utcnow()
+        current_date = datetime.now(tz=timezone.utc)
         year = current_date.year
         current_month = current_date.month
         previous_month = current_month - 1 if current_month - 1 != 0 else 12

--- a/cloud_governance/policy/azure/cleanup/instance_run.py
+++ b/cloud_governance/policy/azure/cleanup/instance_run.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from cloud_governance.policy.helpers.azure.azure_policy_operations import AzurePolicyOperations
 
@@ -19,7 +19,7 @@ class InstanceRun(AzurePolicyOperations):
         """
         instance_types = self._update_instance_type_count()
         account = self.account
-        current_day = datetime.utcnow()
+        current_day = datetime.now(tz=timezone.utc)
         es_instance_types_data = []
         for region, instance_types in instance_types.items():
             for instance_type, instance_type_count in instance_types.items():

--- a/cloud_governance/policy/common_policies/cloudability_cost_reports.py
+++ b/cloud_governance/policy/common_policies/cloudability_cost_reports.py
@@ -55,7 +55,7 @@ class CloudabilityCostReports:
         return (self.__get_end_date() - datetime.timedelta(days=LOOK_BACK_DAYS)).replace(day=1)
 
     def __get_end_date(self):
-        return datetime.datetime.utcnow().date()
+        return datetime.datetime.now(tz=datetime.timezone.utc).date()
 
     def __get_cost_reports(self, start_date: str = None, end_date: str = None, custom_filter: str = ''):
         """
@@ -141,8 +141,8 @@ class CloudabilityCostReports:
         This method returns the next 12 months, year
         :return:
         """
-        year = datetime.datetime.utcnow().year
-        next_month = datetime.datetime.utcnow().month + 1
+        year = datetime.datetime.now(tz=datetime.timezone.utc).year
+        next_month = datetime.datetime.now(tz=datetime.timezone.utc).month + 1
         month_year = []
         for idx in range(MONTHS):
             month = str((idx + next_month) % MONTHS)
@@ -163,12 +163,12 @@ class CloudabilityCostReports:
         """
         forecast_cost_data = []
         month_years = self.__next_twelve_months()
-        month = (datetime.datetime.utcnow().month - 1) % 12
+        month = (datetime.datetime.now(tz=datetime.timezone.utc).month - 1) % 12
         if month == 0:
             month = 12
         if len(str(month)) == 1:
             month = f'0{month}'
-        year = datetime.datetime.utcnow().year
+        year = datetime.datetime.now(tz=datetime.timezone.utc).year
         cache_start_date = f'{year}-{str(month)}-01'
         for data in cost_data:
             if cache_start_date == data.get('start_date') and data.get('CostCenter') > 0:

--- a/cloud_governance/policy/common_policies/send_aggregated_alerts.py
+++ b/cloud_governance/policy/common_policies/send_aggregated_alerts.py
@@ -162,14 +162,14 @@ class SendAggregatedAlerts:
                 if record.get('SkipPolicy') != 'NA':
                     delete_date = 'skip_delete'
                 if days_to_take_action - 5 == days:
-                    delete_date = (datetime.utcnow() + timedelta(days=5)).date()
+                    delete_date = (datetime.now(tz=timezone.utc) + timedelta(days=5)).date()
                     alert_user = True
                 elif days == days_to_take_action - 3:
-                    delete_date = (datetime.utcnow() + timedelta(days=3)).date()
+                    delete_date = (datetime.now(tz=timezone.utc) + timedelta(days=3)).date()
                     alert_user = True
                 else:
                     if days >= days_to_take_action:
-                        delete_date = datetime.utcnow().date().__str__()
+                        delete_date = datetime.now(tz=timezone.utc).date().__str__()
                         alert_user = True
                 # Cross region policies
                 if record.get('policy') in ['empty_roles', 's3_inactive', 'unused_access_key', 'delete_access_key']:

--- a/cloud_governance/policy/helpers/abstract_policy_operations.py
+++ b/cloud_governance/policy/helpers/abstract_policy_operations.py
@@ -14,7 +14,7 @@ class AbstractPolicyOperations(ABC):
     DAYS_TO_NOTIFY_ADMINS = 2
     DAYS_TO_TRIGGER_RESOURCE_MAIL = 4
     DAILY_HOURS = 24
-    CURRENT_DATE = datetime.utcnow().date().__str__()
+    CURRENT_DATE = datetime.now(tz=timezone.utc).date().__str__()
 
     def __init__(self):
         self._environment_variables_dict = environment_variables.environment_variables_dict
@@ -27,7 +27,7 @@ class AbstractPolicyOperations(ABC):
         self._es_upload = ElasticUpload()
         self._shutdown_period = self._environment_variables_dict.get('SHUTDOWN_PERIOD')
 
-    def calculate_days(self, create_date: Union[datetime, str], start_date: Union[datetime, str] = datetime.utcnow()):
+    def calculate_days(self, create_date: Union[datetime, str], start_date: Union[datetime, str] = datetime.now(tz=timezone.utc)):
         """
         This method returns the days
         :param start_date:

--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import typeguard
 
@@ -172,7 +172,7 @@ def zombie_cluster_resource(delete: bool = False, region: str = 'us-east-2', res
                     es_operations.upload_to_elasticsearch(data=zombie_cluster.copy(), index=es_index)
                     logger.info(f'Uploaded the policy results to elasticsearch index: {es_index}')
         else:
-            logger.info(f'No data to upload on @{account}  at {datetime.utcnow()}')
+            logger.info(f'No data to upload on @{account}  at {datetime.now(tz=timezone.utc)}')
     else:
         logger.error('ElasticSearch host is not pingable, Please check ')
     return zombie_result

--- a/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/run_zombie_non_cluster_policies.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/run_zombie_non_cluster_policies.py
@@ -105,7 +105,7 @@ class NonClusterZombiePolicy:
         This method returns the days
         @return:
         """
-        today = datetime.datetime.utcnow().date()
+        today = datetime.datetime.now(tz=datetime.timezone.utc).date()
         days = today - create_date.date()
         return days.days
 

--- a/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/zombie_non_cluster_polices.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/zombie_non_cluster_polices.py
@@ -1,6 +1,6 @@
 import importlib
 import inspect
-from datetime import datetime
+from datetime import datetime, timezone
 
 from cloud_governance.common.logger.init_logger import logger
 from cloud_governance.policy.policy_operations.aws.zombie_non_cluster.run_zombie_non_cluster_policies import NonClusterZombiePolicy
@@ -40,7 +40,7 @@ class ZombieNonClusterPolicies(NonClusterZombiePolicy):
                                     self._es_operations.upload_to_elasticsearch(data=policy_dict.copy(), index=self._es_index)
                             logger.info(f'Uploaded the policy results to elasticsearch index: {self._es_index}')
                         else:
-                            logger.info(f'No data to upload on @{self._account}  at {datetime.utcnow()}')
+                            logger.info(f'No data to upload on @{self._account}  at {datetime.now(tz=timezone.utc)}')
                     else:
                         logger.error('ElasticSearch host is not pingable, Please check ')
 

--- a/cloud_governance/policy/policy_runners/elasticsearch/upload_elastic_search.py
+++ b/cloud_governance/policy/policy_runners/elasticsearch/upload_elastic_search.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Union
 
 from cloud_governance.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
@@ -35,6 +35,6 @@ class UploadElasticSearch(AbstractUpload, ABC):
                             self._es_operations.upload_to_elasticsearch(data=policy_dict.copy(), index=self._es_index)
                     logger.info(f'Uploaded the policy results to elasticsearch index: {self._es_index}')
                 else:
-                    logger.info(f'No data to upload on @{self._account}  at {datetime.utcnow()}')
+                    logger.info(f'No data to upload on @{self._account}  at {datetime.now(tz=timezone.utc)}')
             else:
                 logger.error('ElasticSearch host is not pingable, Please check your connection')

--- a/cloudsensei/agg_lambda/lambda_function.py
+++ b/cloudsensei/agg_lambda/lambda_function.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from time import time
 
 from es_operations import ESOperations
@@ -16,7 +16,7 @@ def lambda_handler(event, context):
     :return:
     """
     start_time = time()
-    logging.info(f"{lambda_handler.__name__} started at {datetime.utcnow()}")
+    logging.info(f"{lambda_handler.__name__} started at {datetime.now(tz=timezone.utc)}")
     aws_accounts = ["perf-dept", "openshift-perfscale", "openshift-psap"]
     code = 400
     message = "Something went wrong check your es_data"
@@ -24,7 +24,7 @@ def lambda_handler(event, context):
     email_body = ""
     subject = "Weekly Cloud Report: Long running instances in the Perf&Scale AWS Accounts"
     for account in aws_accounts:
-        current_date = str(datetime.utcnow().date())
+        current_date = str(datetime.now(tz=timezone.utc).date())
         index_id = f"{account}-{current_date}"
         es_data = es_operations.get_es_data_by_id(index_id)
         if es_data:

--- a/cloudsensei/es_operations.py
+++ b/cloudsensei/es_operations.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 from elasticsearch import Elasticsearch
 
@@ -23,7 +23,7 @@ class ESOperations:
         :return:
         """
         if not data.get('timestamp'):
-            data['timestamp'] = datetime.utcnow()  # datetime.now()
+            data['timestamp'] = datetime.now(tz=timezone.utc)  # datetime.now()
         # Upload data to elastic search server
         try:
             self.__es.index(index=self.ES_INDEX, doc_type=self.ES_DOC, body=data, **kwargs)

--- a/cloudsensei/lambda_function.py
+++ b/cloudsensei/lambda_function.py
@@ -5,7 +5,7 @@ from ast import literal_eval
 from time import time
 
 import boto3
-from datetime import datetime
+from datetime import datetime, timezone
 from jinja2 import Template
 
 from es_operations import ESOperations
@@ -95,7 +95,7 @@ class EC2Operations:
         :return:
         """
         regions = self.__ec2_client.describe_regions()['Regions']
-        current_datetime = datetime.utcnow().date()
+        current_datetime = datetime.now(tz=timezone.utc).date()
         long_running_instances_by_user = {}
         for region in regions:
             region_name = region['RegionName']
@@ -237,7 +237,7 @@ class ProcessData:
         data = {
             'body': organized_ec2_data,
             'subject': self.__subject,
-            'index_id': f"{account_name.lower()}-{str(datetime.utcnow().date())}"
+            'index_id': f"{account_name.lower()}-{str(datetime.now(tz=timezone.utc).date())}"
         }
         if es_operations.upload_to_es(data=data, id=data.get('index_id')):
             return 200, "Successfully save date in elastic search"
@@ -266,7 +266,7 @@ def lambda_handler(event, context):
     :return:
     """
     start_time = time()
-    logging.info(f"{lambda_handler.__name__} started at {datetime.utcnow()}")
+    logging.info(f"{lambda_handler.__name__} started at {datetime.now(tz=timezone.utc)}")
     code = 400
     message = "Something went wrong while sending the Notification"
     extra_message = ''

--- a/cloudsensei/slack_operations.py
+++ b/cloudsensei/slack_operations.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 import requests
 
@@ -42,7 +42,7 @@ class SlackOperations:
         This method sends the header first to create a thread in slack
         :return:
         """
-        header = f":zap: Daily Report @ {datetime.utcnow().date()}: Account *{account_name.title()}* has following long running instances"
+        header = f":zap: Daily Report @ {datetime.now(tz=timezone.utc).date()}: Account *{account_name.title()}* has following long running instances"
         blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": header}}]
         response_data = self.post_message(blocks=blocks)
         if response_data:

--- a/tests/integration/cloud_governance/common/clouds/azure/cost_management/test_cost_management_operations.py
+++ b/tests/integration/cloud_governance/common/clouds/azure/cost_management/test_cost_management_operations.py
@@ -11,7 +11,7 @@ def test_get_usage():
     @return:
     """
     cost_management_operations = CostManagementOperations()
-    end_date = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+    end_date = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=2)
     start_date = end_date - datetime.timedelta(days=1)
     granularity = 'Daily'
     scope = cost_management_operations.azure_operations.get_billing_profiles_list()[0]
@@ -31,7 +31,7 @@ def test_get_forecast():
     @return:
     """
     cost_management_operations = CostManagementOperations()
-    end_date = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    end_date = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=1)
     start_date = end_date - datetime.timedelta(days=1)
     granularity = 'Daily'
     cost_forecast_data = cost_management_operations.get_forecast(scope=cost_management_operations.azure_operations.scope,

--- a/tests/unittest/cloud_governance/cloud_resource_orchestration/mocks/mock_jira.py
+++ b/tests/unittest/cloud_governance/cloud_resource_orchestration/mocks/mock_jira.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import wraps
 from unittest.mock import patch
 
@@ -19,7 +19,7 @@ def get_ticket_response():
     This method return the ticket data
     :return:
     """
-    created = datetime.strftime(datetime.utcnow() - timedelta(days=2), "%Y-%m-%dT%H:%M:%S")
+    created = datetime.strftime(datetime.now(tz=timezone.utc) - timedelta(days=2), "%Y-%m-%dT%H:%M:%S")
     response = {
                 'key': 'MOCK-1',
                 'fields': {
@@ -73,7 +73,7 @@ async def mock_get_all_issues(*args, **kwargs):
                 'key': 'MOCK-1',
                 'fields': {
                     'status': {'name': 'Refinement'},
-                    'created': datetime.utcnow() - timedelta(days=2),
+                    'created': datetime.now(tz=timezone.utc) - timedelta(days=2),
                     'description': "First Name: Test\n"
                                    "Last Name: Mock\nEmail Address: mock@gmail.com\n"
                                    "Manager Approval Address: manager@gmail.com\nCC-Users: \nDays: 5\n"

--- a/tests/unittest/cloud_governance/policy/aws/cleanup/test_database_idle.py
+++ b/tests/unittest/cloud_governance/policy/aws/cleanup/test_database_idle.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from freezegun import freeze_time
 from moto import mock_aws
@@ -9,7 +9,7 @@ from cloud_governance.main.environment_variables import environment_variables
 from tests.unittest.configs import DB_INSTANCE_CLASS, AWS_DEFAULT_REGION, TEST_USER_NAME, DB_ENGINE, \
     CLOUD_WATCH_METRICS_DAYS, PROJECT_NAME
 
-current_date = datetime.utcnow()
+current_date = datetime.now(tz=timezone.utc)
 start_date = current_date - timedelta(days=CLOUD_WATCH_METRICS_DAYS + 1)
 
 

--- a/tests/unittest/cloud_governance/policy/aws/cleanup/test_instance_idle.py
+++ b/tests/unittest/cloud_governance/policy/aws/cleanup/test_instance_idle.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Union
 from unittest.mock import patch
 
@@ -42,7 +42,7 @@ def mock_describe_instances(*args, **kwargs):
                     {
                         'InstanceId': 'i-1234567890abcdef0',
                         'State': {'Name': 'running'},
-                        'LaunchTime': kwargs.get('LaunchTime', datetime.utcnow()),
+                        'LaunchTime': kwargs.get('LaunchTime', datetime.now(tz=timezone.utc)),
                         'Tags': kwargs.get('Tags', []),
                         'PlatformDetails': 'Linux/UNIX'
                         # Change the launch time here
@@ -79,7 +79,7 @@ def test_instance_idle__check_not_idle():
     environment_variables.environment_variables_dict['policy'] = 'instance_idle'
     with patch('boto3.client') as mock_client:
         mock_client.return_value.describe_instances.side_effect = [
-            mock_describe_instances(LaunchTime=datetime.utcnow() - timedelta(days=8))]
+            mock_describe_instances(LaunchTime=datetime.now(tz=timezone.utc) - timedelta(days=8))]
         mock_client.return_value.get_metric_data.side_effect = [
             MockCloudWatchMetric(metrics=[5, 4, 8, 10]).create_metric(),
             MockCloudWatchMetric(metrics=[5000, 2000, 4000, 8000]).create_metric(),
@@ -101,7 +101,7 @@ def test_instance_idle__skip_cluster():
     environment_variables.environment_variables_dict['policy'] = 'instance_idle'
     with patch('boto3.client') as mock_client:
         mock_client.return_value.describe_instances.side_effect = [
-            mock_describe_instances(Tags=tags, LaunchTime=datetime.utcnow() - timedelta(days=8))]
+            mock_describe_instances(Tags=tags, LaunchTime=datetime.now(tz=timezone.utc) - timedelta(days=8))]
         instance_idle = InstanceIdle()
         response = instance_idle.run()
         assert len(response) == 0
@@ -118,7 +118,7 @@ def test_instance_idle__dryrun_no_active_instance():
     environment_variables.environment_variables_dict['policy'] = 'instance_idle'
     with patch('boto3.client') as mock_client:
         mock_client.return_value.describe_instances.side_effect = [
-            mock_describe_instances(Tags=tags, LaunchTime=datetime.utcnow() - timedelta(days=8))]
+            mock_describe_instances(Tags=tags, LaunchTime=datetime.now(tz=timezone.utc) - timedelta(days=8))]
         mock_client.return_value.get_metric_data.side_effect = [
             MockCloudWatchMetric(metrics=[5, 4, 8, 10]).create_metric(),
             MockCloudWatchMetric(metrics=[5000, 2000, 4000, 8000]).create_metric(),
@@ -140,7 +140,7 @@ def test_instance_idle__dryrun_no_delete():
     environment_variables.environment_variables_dict['policy'] = 'instance_idle'
     with patch('boto3.client') as mock_client:
         mock_client.return_value.describe_instances.side_effect = [
-            mock_describe_instances(Tags=tags, LaunchTime=datetime.utcnow() - timedelta(days=8))]
+            mock_describe_instances(Tags=tags, LaunchTime=datetime.now(tz=timezone.utc) - timedelta(days=8))]
         mock_client.return_value.get_metric_data.side_effect = [
             MockCloudWatchMetric(metrics=[0, 1, 0, 0.1]).create_metric(),
             MockCloudWatchMetric(metrics=[50, 20, 5, 10]).create_metric(),
@@ -165,7 +165,7 @@ def test_instance_idle__skips_delete():
     environment_variables.environment_variables_dict['policy'] = 'instance_idle'
     with patch('boto3.client') as mock_client:
         mock_client.return_value.describe_instances.side_effect = [
-            mock_describe_instances(Tags=tags, LaunchTime=datetime.utcnow() - timedelta(days=8))]
+            mock_describe_instances(Tags=tags, LaunchTime=datetime.now(tz=timezone.utc) - timedelta(days=8))]
         mock_client.return_value.get_metric_data.side_effect = [
             MockCloudWatchMetric(metrics=[0, 1, 0, 0.1]).create_metric(),
             MockCloudWatchMetric(metrics=[50, 20, 5, 10]).create_metric(),
@@ -187,7 +187,7 @@ def test_instance_idle__set_counter_zero():
     environment_variables.environment_variables_dict['policy'] = 'instance_idle'
     with patch('boto3.client') as mock_client:
         mock_client.return_value.describe_instances.side_effect = [
-            mock_describe_instances(Tags=tags, LaunchTime=datetime.utcnow() - timedelta(days=8))]
+            mock_describe_instances(Tags=tags, LaunchTime=datetime.now(tz=timezone.utc) - timedelta(days=8))]
         mock_client.return_value.get_metric_data.side_effect = [
             MockCloudWatchMetric(metrics=[0, 1, 0, 0.1]).create_metric(),
             MockCloudWatchMetric(metrics=[50, 20, 5, 10]).create_metric(),

--- a/tests/unittest/cloud_governance/policy/aws/cleanup/test_unused_nat_gateway.py
+++ b/tests/unittest/cloud_governance/policy/aws/cleanup/test_unused_nat_gateway.py
@@ -55,7 +55,7 @@ def test_unused_nat_gateway_dry_run_yes_collect_none():
                     'Value': nat_gateway.get('NatGatewayId')
                 },
             ],
-            'Timestamp': datetime.datetime.utcnow() - datetime.timedelta(hours=12),
+            'Timestamp': datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(hours=12),
             'Value': 123.0,
             'Unit': 'Count',
         }
@@ -99,7 +99,7 @@ def test_unused_nat_gateway___dry_run_no_7_days_action_delete():
     environment_variables.environment_variables_dict['dry_run'] = 'no'
     ec2_client = boto3.client('ec2', region_name=AWS_DEFAULT_REGION)
     subnet_id = ec2_client.describe_subnets()['Subnets'][0].get('SubnetId')
-    tags = [{'Key': 'DaysCount', 'Value': f'{datetime.datetime.utcnow().date()}@7'}]
+    tags = [{'Key': 'DaysCount', 'Value': f'{datetime.datetime.now(tz=datetime.timezone.utc).date()}@7'}]
     ec2_client.create_nat_gateway(SubnetId=subnet_id, TagSpecifications=[{'ResourceType': 'nat-gateway', 'Tags': tags}])
     unused_nat_gateway = UnUsedNatGateway()
     response = unused_nat_gateway.run()
@@ -121,7 +121,7 @@ def test_unused_nat_gateway___dry_run_no_skips_delete():
     environment_variables.environment_variables_dict['dry_run'] = 'no'
     ec2_client = boto3.client('ec2', region_name=AWS_DEFAULT_REGION)
     subnet_id = ec2_client.describe_subnets()['Subnets'][0].get('SubnetId')
-    tags = [{'Key': 'DaysCount', 'Value': f'{datetime.datetime.utcnow().date()}@7'},
+    tags = [{'Key': 'DaysCount', 'Value': f'{datetime.datetime.now(tz=datetime.timezone.utc).date()}@7'},
             {'Key': 'policy', 'Value': 'not-delete'}]
     ec2_client.create_nat_gateway(SubnetId=subnet_id, TagSpecifications=[{'ResourceType': 'nat-gateway', 'Tags': tags}])
     unused_nat_gateway = UnUsedNatGateway()

--- a/tests/unittest/cloud_governance/policy/aws/test_zombie_snapshots.py
+++ b/tests/unittest/cloud_governance/policy/aws/test_zombie_snapshots.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import boto3
@@ -68,7 +68,7 @@ def test_zombie_snapshots_delete():
     environment_variables.environment_variables_dict['AWS_DEFAULT_REGION'] = AWS_DEFAULT_REGION
     environment_variables.environment_variables_dict['policy'] = 'zombie_snapshots'
     tags = [{'Key': 'User', 'Value': TEST_USER_NAME},
-            {'Key': 'DaysCount', 'Value': f'{datetime.utcnow().date()}@7'}]
+            {'Key': 'DaysCount', 'Value': f'{datetime.now(tz=timezone.utc).date()}@7'}]
     ec2_client = boto3.client('ec2', region_name=AWS_DEFAULT_REGION)
 
     # delete default snapshots and images
@@ -109,7 +109,7 @@ def test_zombie_snapshots_skip():
     environment_variables.environment_variables_dict['AWS_DEFAULT_REGION'] = AWS_DEFAULT_REGION
     environment_variables.environment_variables_dict['policy'] = 'zombie_snapshots'
     tags = [{'Key': 'User', 'Value': TEST_USER_NAME}, {'Key': 'policy', 'Value': 'not-delete'},
-            {'Key': 'DaysCount', 'Value': f'{datetime.utcnow().date()}@7'}]
+            {'Key': 'DaysCount', 'Value': f'{datetime.now(tz=timezone.utc).date()}@7'}]
     ec2_client = boto3.client('ec2', region_name=AWS_DEFAULT_REGION)
 
     # delete default snapshots and images
@@ -152,7 +152,7 @@ def test_zombie_snapshots_contains_cluster_tag():
     environment_variables.environment_variables_dict['AWS_DEFAULT_REGION'] = AWS_DEFAULT_REGION
     environment_variables.environment_variables_dict['policy'] = 'zombie_snapshots'
     tags = [{'Key': 'User', 'Value': TEST_USER_NAME}, {'Key': 'policy', 'Value': 'not-delete'},
-            {'Key': 'DaysCount', 'Value': f'{datetime.utcnow().date()}@7'},
+            {'Key': 'DaysCount', 'Value': f'{datetime.now(tz=timezone.utc).date()}@7'},
             {'Key': 'kubernetes.io/cluster/test-zombie-cluster', 'Value': f'owned'}]
     ec2_client = boto3.client('ec2', region_name=AWS_DEFAULT_REGION)
 
@@ -192,7 +192,7 @@ def test_zombie_snapshots_no_zombies():
     environment_variables.environment_variables_dict['AWS_DEFAULT_REGION'] = AWS_DEFAULT_REGION
     environment_variables.environment_variables_dict['policy'] = 'zombie_snapshots'
     tags = [{'Key': 'User', 'Value': TEST_USER_NAME}, {'Key': 'policy', 'Value': 'not-delete'},
-            {'Key': 'DaysCount', 'Value': f'{datetime.utcnow().date()}@7'}]
+            {'Key': 'DaysCount', 'Value': f'{datetime.now(tz=timezone.utc).date()}@7'}]
     snapshot_id = 'mock_snapshot_id'
     image_id = 'mock_image_id'
 

--- a/tests/unittest/cloud_governance/policy/azure/test_instance_idle.py
+++ b/tests/unittest/cloud_governance/policy/azure/test_instance_idle.py
@@ -36,17 +36,17 @@ def test_instance_idle():
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-cpu-metric',
                                          unit='Percentage CPU',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-in-metric',
                                          unit='Network In Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-out-metric',
                                          unit='Network Out Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     instance_idle = InstanceIdle()
     response = instance_idle.run()
@@ -72,17 +72,17 @@ def test_instance_idle__check_not_idle():
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-cpu-metric',
                                          unit='Percentage CPU',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=3)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=3)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-in-metric',
                                          unit='Network In Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-out-metric',
                                          unit='Network Out Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     instance_idle = InstanceIdle()
     response = instance_idle.run()
@@ -130,17 +130,17 @@ def test_instance_idle__dryrun_no():
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-cpu-metric',
                                          unit='Percentage CPU',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=3)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=3)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-in-metric',
                                          unit='Network In Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=10000)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=10000)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-out-metric',
                                          unit='Network Out Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=10000)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=10000)
                                          ])])
     instance_idle = InstanceIdle()
     response = instance_idle.run()
@@ -167,17 +167,17 @@ def test_instance_idle__dryrun_no_delete():
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-cpu-metric',
                                          unit='Percentage CPU',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-in-metric',
                                          unit='Network In Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-out-metric',
                                          unit='Network Out Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     instance_idle = InstanceIdle()
     response = instance_idle.run()
@@ -206,17 +206,17 @@ def test_instance_idle__skips_delete():
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-cpu-metric',
                                          unit='Percentage CPU',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-in-metric',
                                          unit='Network In Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-out-metric',
                                          unit='Network Out Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     instance_idle = InstanceIdle()
     response = instance_idle.run()
@@ -245,17 +245,17 @@ def test_instance_idle__set_counter_zero():
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-cpu-metric',
                                          unit='Percentage CPU',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-in-metric',
                                          unit='Network In Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     monitor_client.metrics.create_metric(resource_id=instance.id, type='VirtualMachine', name='test-network-out-metric',
                                          unit='Network Out Total',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     instance_idle = InstanceIdle()
     response = instance_idle.run()

--- a/tests/unittest/cloud_governance/policy/azure/test_instance_run.py
+++ b/tests/unittest/cloud_governance/policy/azure/test_instance_run.py
@@ -114,7 +114,7 @@ def test_instance_run_stopped_test_days():
     environment_variables.environment_variables_dict['SHUTDOWN_PERIOD'] = True
     environment_variables.environment_variables_dict['policy'] = 'instance_run'
     environment_variables.environment_variables_dict['dry_run'] = 'no'
-    date = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).date()
+    date = (datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=1)).date()
     mock_virtual_machines = Mock()
     vm1 = MockVirtualMachine(tags={'User': 'mock', 'Policy': 'notdelete',
                                    'DaysCount': f'{date}@1'})
@@ -144,7 +144,7 @@ def test_instance_run_stopped_test_current_day():
     environment_variables.environment_variables_dict['SHUTDOWN_PERIOD'] = True
     environment_variables.environment_variables_dict['policy'] = 'instance_run'
     environment_variables.environment_variables_dict['dry_run'] = 'no'
-    date = (datetime.datetime.utcnow()).date()
+    date = (datetime.datetime.now(tz=datetime.timezone.utc)).date()
     mock_virtual_machines = Mock()
     vm1 = MockVirtualMachine(tags={'User': 'mock', 'Policy': 'notdelete',
                                    'DaysCount': f'{date}@1'})
@@ -174,7 +174,7 @@ def test_instance_run_vm_already_stopped():
     environment_variables.environment_variables_dict['policy'] = 'instance_run'
     environment_variables.environment_variables_dict['SHUTDOWN_PERIOD'] = True
     environment_variables.environment_variables_dict['dry_run'] = 'no'
-    date = (datetime.datetime.utcnow()).date()
+    date = (datetime.datetime.now(tz=datetime.timezone.utc)).date()
     mock_virtual_machines = Mock()
     vm1 = MockVirtualMachine(tags={'User': 'mock', 'Policy': 'notdelete',
                                    'DaysCount': f'{date}@1'})

--- a/tests/unittest/cloud_governance/policy/azure/test_unused_nat_gateway.py
+++ b/tests/unittest/cloud_governance/policy/azure/test_unused_nat_gateway.py
@@ -52,7 +52,7 @@ def test_unused_nat_gateway__check_used():
     monitor_client.metrics.create_metric(resource_id=nat_gateway.id, type='NatGateway', name='test-metric',
                                          unit='SNATConnectionCount',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=100)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=100)
                                          ])])
     unused_nat_gateway = UnUsedNatGateway()
     response = unused_nat_gateway.run()
@@ -79,7 +79,7 @@ def test_unused_nat_gateway__skip_live_cluster_id():
     monitor_client.metrics.create_metric(resource_id=nat_gateway.id, type='NatGateway', name='test-metric',
                                          unit='SNATConnectionCount',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     unused_nat_gateway = UnUsedNatGateway()
     response = unused_nat_gateway.run()
@@ -104,7 +104,7 @@ def test_unused_nat_gateway__collect_not_live_cluster_id():
     monitor_client.metrics.create_metric(resource_id=nat_gateway.id, type='NatGateway', name='test-metric',
                                          unit='SNATConnectionCount',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     unused_nat_gateway = UnUsedNatGateway()
     response = unused_nat_gateway.run()
@@ -129,7 +129,7 @@ def test_unused_nat_gateway__dryrun_no():
     monitor_client.metrics.create_metric(resource_id=nat_gateway.id, type='NatGateway', name='test-metric',
                                          unit='SNATConnectionCount',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     unused_nat_gateway = UnUsedNatGateway()
     response = unused_nat_gateway.run()
@@ -154,7 +154,7 @@ def test_unused_nat_gateway__dryrun_no_delete():
     monitor_client.metrics.create_metric(resource_id=nat_gateway.id, type='NatGateway', name='test-metric',
                                          unit='SNATConnectionCount',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     unused_nat_gateway = UnUsedNatGateway()
     response = unused_nat_gateway.run()
@@ -181,7 +181,7 @@ def test_unused_nat_gateway__skips_delete():
     monitor_client.metrics.create_metric(resource_id=nat_gateway.id, type='NatGateway', name='test-metric',
                                          unit='SNATConnectionCount',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     unused_nat_gateway = UnUsedNatGateway()
     response = unused_nat_gateway.run()
@@ -208,7 +208,7 @@ def test_unused_nat_gateway__set_counter_zero():
     monitor_client.metrics.create_metric(resource_id=nat_gateway.id, type='NatGateway', name='test-metric',
                                          unit='SNATConnectionCount',
                                          timeseries=[TimeSeriesElement(data=[
-                                             MetricValue(time_stamp=datetime.datetime.utcnow(), average=0)
+                                             MetricValue(time_stamp=datetime.datetime.now(tz=datetime.timezone.utc), average=0)
                                          ])])
     unused_nat_gateway = UnUsedNatGateway()
     response = unused_nat_gateway.run()

--- a/tests/unittest/cloud_governance/policy/helpers/aws/test_aws_policy_operations.py
+++ b/tests/unittest/cloud_governance/policy/helpers/aws/test_aws_policy_operations.py
@@ -43,7 +43,7 @@ def test_get_clean_up_days_count_already_exists():
     """
     environment_variables.environment_variables_dict['dry_run'] = 'yes'
     aws_cleanup_operations = AWSPolicyOperations()
-    mock_date = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).date()
+    mock_date = (datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=1)).date()
     tags = [{'Key': "Name", "Value": "Unittest"}, {'Key': "DaysCount", "Value": f'{mock_date}@1'}]
     days_count = aws_cleanup_operations.get_clean_up_days_count(tags=tags)
     assert days_count == 0
@@ -58,7 +58,7 @@ def test_get_clean_up_days_count_already_updated_today():
     """
     environment_variables.environment_variables_dict['dry_run'] = 'yes'
     aws_cleanup_operations = AWSPolicyOperations()
-    mock_date = str(datetime.datetime.utcnow().date())
+    mock_date = str(datetime.datetime.now(tz=datetime.timezone.utc).date())
     tags = [{'Key': "Name", "Value": "Unittest"}, {'Key': "DaysCount", "Value": f'{mock_date}@1'}]
     days_count = aws_cleanup_operations.get_clean_up_days_count(tags=tags)
     assert days_count == 0
@@ -135,7 +135,7 @@ def test_update_resource_day_count_tag():
         aws_cleanup_operations.update_resource_day_count_tag(resource_id=resource_id, cleanup_days=cleanup_days, tags=tags)
         instances = ec2_client.describe_instances()['Reservations']
         tag_value = aws_cleanup_operations.get_tag_name_from_tags(instances[0]['Instances'][0].get('Tags'), tag_name='DaysCount')
-        assert tag_value == str(datetime.datetime.utcnow().date()) + "@0"
+        assert tag_value == str(datetime.datetime.now(tz=datetime.timezone.utc).date()) + "@0"
 
 
 @mock_aws
@@ -150,7 +150,7 @@ def test_update_resource_day_count_tag_exists_tag():
     environment_variables.environment_variables_dict['dry_run'] = 'no'
     ec2_client = boto3.client('ec2', region_name='ap-south-1')
     default_ami_id = 'ami-03cf127a'
-    mock_date = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).date()
+    mock_date = (datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=1)).date()
     tags = [{'Key': 'User', 'Value': 'cloud-governance'}, {'Key': "Name", "Value": "Unittest"},
             {'Key': "DaysCount", "Value": f'{mock_date}@1'}]
     resource = ec2_client.run_instances(ImageId=default_ami_id, InstanceType='t2.micro', MaxCount=1, MinCount=1,
@@ -163,7 +163,7 @@ def test_update_resource_day_count_tag_exists_tag():
         aws_cleanup_operations.update_resource_day_count_tag(resource_id=resource_id, cleanup_days=cleanup_days, tags=tags)
         instances = ec2_client.describe_instances()['Reservations']
         tag_value = aws_cleanup_operations.get_tag_name_from_tags(instances[0]['Instances'][0].get('Tags'), tag_name='DaysCount')
-        assert tag_value == str(datetime.datetime.utcnow().date()) + "@2"
+        assert tag_value == str(datetime.datetime.now(tz=datetime.timezone.utc).date()) + "@2"
 
 
 @mock_aws
@@ -178,7 +178,7 @@ def test_update_resource_day_count_tag_updated_tag_today():
     environment_variables.environment_variables_dict['dry_run'] = 'no'
     ec2_client = boto3.client('ec2', region_name='ap-south-1')
     default_ami_id = 'ami-03cf127a'
-    mock_date = datetime.datetime.utcnow().date()
+    mock_date = datetime.datetime.now(tz=datetime.timezone.utc).date()
     tags = [{'Key': 'User', 'Value': 'cloud-governance'}, {'Key': "Name", "Value": "Unittest"},
             {'Key': "DryRunYesDays", "Value": f'{mock_date}@1'}]
     resource = ec2_client.run_instances(ImageId=default_ami_id, InstanceType='t2.micro', MaxCount=1, MinCount=1,
@@ -191,4 +191,4 @@ def test_update_resource_day_count_tag_updated_tag_today():
         aws_cleanup_operations.update_resource_day_count_tag(resource_id=resource_id, cleanup_days=cleanup_days, tags=tags)
         instances = ec2_client.describe_instances()['Reservations']
         tag_value = aws_cleanup_operations.get_tag_name_from_tags(instances[0]['Instances'][0].get('Tags'), tag_name='DaysCount')
-        assert tag_value == str(datetime.datetime.utcnow().date()) + "@1"
+        assert tag_value == str(datetime.datetime.now(tz=datetime.timezone.utc).date()) + "@1"

--- a/tests/unittest/configs.py
+++ b/tests/unittest/configs.py
@@ -6,8 +6,8 @@ PROJECT_NAME = 'cloud_governance'
 
 DRY_RUN_YES = 'yes'
 DRY_RUN_NO = 'no'
-CURRENT_DATE = datetime.datetime.utcnow().date()
-CURRENT_DATE_TIME = datetime.datetime.utcnow()
+CURRENT_DATE = datetime.datetime.now(tz=datetime.timezone.utc).date()
+CURRENT_DATE_TIME = datetime.datetime.now(tz=datetime.timezone.utc)
 TEST_USER_NAME = 'unit-test'
 
 # AWS

--- a/tests/unittest/mocks/azure/mock_computes.py
+++ b/tests/unittest/mocks/azure/mock_computes.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from azure.mgmt.compute.v2023_01_02.models import Disk, DiskSku
 from azure.mgmt.compute.v2023_03_01.models import VirtualMachine, HardwareProfile, VirtualMachineInstanceView, \
@@ -14,7 +14,7 @@ class MockVirtualMachine(VirtualMachine):
         super().__init__(location='mock')
         self.tags = tags if tags else {}
         self.name = 'mock_machine'
-        self.time_created = datetime.utcnow()
+        self.time_created = datetime.now(tz=timezone.utc)
         self.hardware_profile = HardwareProfile(vm_size='Standard_D2s_v3')
         self.id = f'/subscriptions/{uuid.uuid1()}/resourceGroups/mock/providers/Microsoft.Compute/virtualMachines/mock-machine'
 


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [x] dependencies

## Description
Replaced all datetime.utcnow() calls (deprecated since Python 3.12) with the recommended timezone-aware alternative.

## For security reasons, all pull requests need to be approved first before running any automated CI
