### PR TITLE
Add image expiry label for quay cloud governance images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.14-slim
 
+LABEL quay.expires-after=365d
+
 # cloud-governance latest version
 ARG VERSION
 


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Add automatic expiration for cloud-governance images, currently set to 365 days.

## For security reasons, all pull requests need to be approved first before running any automated CI
