### PR TITLE
Fix ElasticSearch UnsupportedProductError

### DIFF
--- a/cloud_governance/common/elasticsearch/elasticsearch_operations.py
+++ b/cloud_governance/common/elasticsearch/elasticsearch_operations.py
@@ -54,6 +54,8 @@ class ElasticSearchOperations:
             self.__es = Elasticsearch([add_host],
                                       timeout=self.__timeout,
                                       max_retries=2)
+            # Skip product check for OpenSearch compatibility (elasticsearch-py 7.14+ rejects non-Elasticsearch servers)
+            self.__es.transport._verified_elasticsearch = True
         except Exception as err:
             self.__es = None
 

--- a/cloud_governance/common/elasticsearch/elasticsearch_operations.py
+++ b/cloud_governance/common/elasticsearch/elasticsearch_operations.py
@@ -54,10 +54,15 @@ class ElasticSearchOperations:
             self.__es = Elasticsearch([add_host],
                                       timeout=self.__timeout,
                                       max_retries=2)
-            # Skip product check for OpenSearch compatibility (elasticsearch-py 7.14+ rejects non-Elasticsearch servers)
-            self.__es.transport._verified_elasticsearch = True
         except Exception as err:
             self.__es = None
+
+        # Skip product check for OpenSearch compatibility (elasticsearch-py 7.14+ rejects non-Elasticsearch servers)
+        try:
+            if self.__es and hasattr(self.__es.transport, '_verified_elasticsearch'):
+                self.__es.transport._verified_elasticsearch = True
+        except AttributeError as err:
+            logger.warning(f"Could not bypass Elasticsearch product check: {err}")
 
     def __elasticsearch_get_index_hits(self, index: str, uuid: str = '', workload: str = '', fast_check: bool = False,
                                        id: bool = False):


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
The elasticsearch-py 7.14+ client introduced a product verification check that rejects connections to non-Elasticsearch servers. Since we connect to OpenSearch 1.2.4, the client throws UnsupportedProductError on the first request (ping()), preventing all data uploads. 

Fix : Bypass the product verification by setting transport._verified_elasticsearch = True immediately after client initialization, before any requests are made. This skips the server product check while preserving all existing client functionality.


## For security reasons, all pull requests need to be approved first before running any automated CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Elasticsearch/OpenSearch client compatibility.
  * Added graceful handling during client initialization; emits a warning when certain client verification details are unavailable to avoid failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->