### PR TITLE
Remove ecoeng accounts, cluster policies from daily run

### DIFF
--- a/jenkins/tenant/aws/ecoeng_01/PolicyJenkinsfileDaily
+++ b/jenkins/tenant/aws/ecoeng_01/PolicyJenkinsfileDaily
@@ -1,5 +1,4 @@
 accounts_list = ['industry-partners': "hhalbfin@redhat.com",
-                 'certification-pipeline': "matt.dorn@redhat.com, mhillsma@redhat.com, babak@redhat.com, hhalbfin@redhat.com",
                  'ecoengverticals-qe': "augol@redhat.com, hhalbfin@redhat.com",
                  'emerge-partner': "jsalomon@redhat.com, ltomasbo@redhat.com, hhalbfin@redhat.com",
                  'telco5g-ci': "yjoseph@redhat.com, hhalbfin@redhat.com, sshnaidm@redhat.com",
@@ -9,9 +8,7 @@ accounts_list = ['industry-partners': "hhalbfin@redhat.com",
                  'special-projects': "chen.yosef@redhat.com, hhalbfin@redhat.com",
                  'edgeinfra': "lgamliel@redhat.com, bthurber@redhat.com, oourfali@redhat.com, hhalbfin@redhat.com",
                  'specialprojects-qe': "augol@redhat.com, hhalbfin@redhat.com",
-                 'partnerlab': "matt.dorn@redhat.com, jomckenz@redhat.com, babak@redhat.com, hhalbfin@redhat.com, mrhillsman@redhat.com",
                  'blueprints': "abeekhof@redhat.com, hhalbfin@redhat.com",
-                 'coreos-training': "matt.dorn@redhat.com, jomckenz@redhat.com, babak@redhat.com, hhalbfin@redhat.com, mrhillsman@redhat.com",
                  'edgeinfra-ci': "rfreiman@redhat.com, hhalbfin@redhat.com",
                  'ecoeng-flightctl': "ayogev@redhat.com, hhalbfin@redhat.com",
                  'partners-eng': "hhalbfin@redhat.com",
@@ -47,7 +44,7 @@ pipeline {
         // Find the all available policies: https://github.com/redhat-performance/cloud-governance/tree/main/cloud_governance/policy
         // By default, all policies are running in dry_run="yes" mode and the whole list can be found in run_policies.py
         // POLICIES_IN_ACTION: Policies that run in the dry_run="no" mode
-        POLICIES_IN_ACTION = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "zombie_cluster_resource"]'
+        POLICIES_IN_ACTION = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles"]'
         SKIP_POLICIES_ALERT = '["unused_access_key"]'
     }
     stages {

--- a/jenkins/tenant/aws/ecoeng_01/README.md
+++ b/jenkins/tenant/aws/ecoeng_01/README.md
@@ -1,14 +1,13 @@
 ### ecoeng_01 - dry_run=no
 
 **POLICIES_IN_ACTION
-** = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "zombie_cluster_resource"]'
+** = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles"]'
 
-- Run zombie_cluster_resource in blueprints
+- zombie_cluster_resource removed from POLICIES_IN_ACTION (runs as dry_run=yes only) due to Hypershift incompatibility
 
 Accounts:
 
 - **industry-partners**: "hhalbfin@redhat.com",
-- **certification-pipeline**: "matt.dorn@redhat.com, mhillsma@redhat.com, babak@redhat.com, hhalbfin@redhat.com",
 - **ecoengverticals-qe**: "augol@redhat.com, hhalbfin@redhat.com",
 - **emerge-partner**: "jsalomon@redhat.com, ltomasbo@redhat.com, hhalbfin@redhat.com",
 - **telco5g-ci**: "yjoseph@redhat.com, hhalbfin@redhat.com",
@@ -19,7 +18,6 @@ Accounts:
 - **special-projects**: "chen.yosef@redhat.com, hhalbfin@redhat.com",
 - **edgeinfra**: "lgamliel@redhat.com, bthurber@redhat.com, oourfali@redhat.com, hhalbfin@redhat.com",
 - **specialprojects-qe**: "augol@redhat.com, hhalbfin@redhat.com",
-- **partnerlab**: "matt.dorn@redhat.com, jomckenz@redhat.com, babak@redhat.com, hhalbfin@redhat.com",
 - **blueprints**: "abeekhof@redhat.com, hhalbfin@redhat.com",
 - **edgeinfra-ci**: "rfreiman@redhat.com, hhalbfin@redhat.com",
 - **ecoeng-flightctl**:  "ayogev@redhat.com, hhalbfin@redhat.com",


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [x] dependencies

## Description
1. Remove ecoeng accounts from daily policies run:

- certification-pipeline
- coreos-training
- partnerlab

2. Move zombie_cluster_resources from dry_run 'no'

## For security reasons, all pull requests need to be approved first before running any automated CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * `zombie_cluster_resource` policy no longer executes in non-dry-run mode
  * Removed multiple AWS accounts from daily policy execution workflow
* **Documentation**
  * Updated policy configuration and account list documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->