### PR TITLE
Fix multiple 'Deleted' strings from logs

### DIFF
--- a/cloud_governance/policy/aws/cleanup/unused_nat_gateway.py
+++ b/cloud_governance/policy/aws/cleanup/unused_nat_gateway.py
@@ -85,9 +85,9 @@ class UnUsedNatGateway(AWSPolicyOperations):
                                                         resource_action=self.RESOURCE_ACTION,
                                                         cloud_name=self._cloud_name,
                                                         resource_type='NatGateway',
-                                                        resource_state=nat_gateway.get('State'),
-                                                        unit_price=unit_price
-                                                        if not cleanup_result else "Deleted")
+                                                        resource_state=nat_gateway.get('State')
+                                                        if not cleanup_result else "Deleted",
+                                                        unit_price=unit_price)
                     unused_nat_gateways.append(resource_data)
                     if not cleanup_result:
                         self.update_resource_tags(resource_id=resource_id, tags=tags + self.cost_savings_tag)


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Issue
In the unused_nat_gateway.py policy, when a NAT Gateway was successfully deleted, the code was setting unit_price="Deleted" (a string) instead of keeping it as a numeric value.

The _get_es_schema method then tries to calculate TotalYearlySavings by calling __current_savings_year(unit_price), which does:

total_days * 24 * unit_price

When unit_price is the string "Deleted", Python's string multiplication creates:

24 * "Deleted" = "Deleted" repeated 24 times

Then total_days * (that result) = "Deleted" repeated ~4,000+ times (24 hours × ~175 days remaining in year)

## For security reasons, all pull requests need to be approved first before running any automated CI

_Assisted-by: Cursor_
