### PR TITLE
Fix case sensitive environment variable lookup

### DIFF
--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -392,17 +392,18 @@ class EnvironmentVariables:
     def get_env(var: str, defval=''):
         lcvar = var.lower()
         dashvar = lcvar.replace('_', '-')
+        env_value = os.environ.get(var) or os.environ.get(var.upper()) or os.environ.get(var.lower()) or defval
         parser = argparse.ArgumentParser(description='Run CloudGovernance', allow_abbrev=False)
         if lcvar == dashvar:
-            parser.add_argument(f"--{lcvar}", default=os.environ.get(var, defval), type=str, metavar='String', help=var)
+            parser.add_argument(f"--{lcvar}", default=env_value, type=str, metavar='String', help=var)
         else:
-            parser.add_argument(f"--{lcvar}", f"--{dashvar}", default=os.environ.get(var, defval), type=str,
+            parser.add_argument(f"--{lcvar}", f"--{dashvar}", default=env_value, type=str,
                                 metavar='String', help=var)
         args, ignore = parser.parse_known_args()
         if hasattr(args, lcvar):
             return getattr(args, lcvar)
         else:
-            return os.environ.get(var, defval)
+            return env_value
 
     @staticmethod
     def get_boolean_from_environment(var: str, defval: bool):


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
The get_env() method was case-sensitive when looking up environment variables. Jenkins sets:
ES_HOST (uppercase)
ES_PORT (uppercase)

But the code was looking for:
es_host (lowercase)
es_port (lowercase)

On Linux/Unix systems, os.environ is case-sensitive, so os.environ.get('es_port') won't find ES_PORT, returning an empty string ''. Then when the code tried to do int('') on line 53 or 63 of elasticsearch_operations.py, it failed with invalid literal for int() with base 10: ''.

## Fix
Updated the get_env() method in environment_variables.py to check for the variable in multiple case variations

## For security reasons, all pull requests need to be approved first before running any automated CI

_Assisted-by: Cursor_