### PR TITLE
Azure Monitor API rejecting timespan format

### DIFF
--- a/cloud_governance/common/clouds/azure/monitor/monitor_management_operations.py
+++ b/cloud_governance/common/clouds/azure/monitor/monitor_management_operations.py
@@ -81,7 +81,7 @@ class MonitorManagementOperations(CommonOperations):
         if not timespan:
             end_date = datetime.now(tz=timezone.utc)
             start_date = end_date - timedelta(days=UNUSED_DAYS)
-            timespan = f'{start_date}/{end_date}'
+            timespan = f'{start_date.isoformat()}/{end_date.isoformat()}'
         response = self.__monitor_client.metrics.list(resource_uri=resource_id, timespan=timespan,
                                                       metricnames=metricnames, aggregation=aggregation,
                                                       result_type='Data', interval=interval,

--- a/cloud_governance/policy/helpers/azure/azure_policy_operations.py
+++ b/cloud_governance/policy/helpers/azure/azure_policy_operations.py
@@ -199,7 +199,7 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         start_date, end_date = Utils.get_start_and_end_datetime(days=days)
-        timespan = f'{start_date}/{end_date}'
+        timespan = f'{start_date.isoformat()}/{end_date.isoformat()}'
         cpu_metrics = self.monitor_operations.get_resource_metrics(resource_id=resource_id,
                                                                    metricnames='Percentage CPU',
                                                                    aggregation='Average',
@@ -218,7 +218,7 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         start_date, end_date = Utils.get_start_and_end_datetime(days=days)
-        timespan = f'{start_date}/{end_date}'
+        timespan = f'{start_date.isoformat()}/{end_date.isoformat()}'
         network_in_metrics = self.monitor_operations.get_resource_metrics(resource_id=resource_id,
                                                                           metricnames='Network In Total',
                                                                           aggregation='Average',
@@ -238,7 +238,7 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         start_date, end_date = Utils.get_start_and_end_datetime(days=days)
-        timespan = f'{start_date}/{end_date}'
+        timespan = f'{start_date.isoformat()}/{end_date.isoformat()}'
         network_out_metrics = self.monitor_operations.get_resource_metrics(resource_id=resource_id,
                                                                            metricnames='Network Out Total',
                                                                            aggregation='Average',


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [x] dependencies

## Description
Problem: Azure Monitor API was rejecting timespan format due to non-ISO 8601 datetime formatting. Found from azure daily policies run Jenkins job.

## For security reasons, all pull requests need to be approved first before running any automated CI

_Assisted-by: Cursor_
