### PR TITLE
Fix Azure Monitor API timespan format to use 'Z' for UTC

### DIFF
--- a/cloud_governance/common/clouds/azure/monitor/monitor_management_operations.py
+++ b/cloud_governance/common/clouds/azure/monitor/monitor_management_operations.py
@@ -81,7 +81,7 @@ class MonitorManagementOperations(CommonOperations):
         if not timespan:
             end_date = datetime.now(tz=timezone.utc)
             start_date = end_date - timedelta(days=UNUSED_DAYS)
-            timespan = f'{start_date.isoformat()}/{end_date.isoformat()}'
+            timespan = f'{start_date.strftime("%Y-%m-%dT%H:%M:%SZ")}/{end_date.strftime("%Y-%m-%dT%H:%M:%SZ")}'
         response = self.__monitor_client.metrics.list(resource_uri=resource_id, timespan=timespan,
                                                       metricnames=metricnames, aggregation=aggregation,
                                                       result_type='Data', interval=interval,

--- a/cloud_governance/policy/helpers/azure/azure_policy_operations.py
+++ b/cloud_governance/policy/helpers/azure/azure_policy_operations.py
@@ -199,7 +199,7 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         start_date, end_date = Utils.get_start_and_end_datetime(days=days)
-        timespan = f'{start_date.isoformat()}/{end_date.isoformat()}'
+        timespan = f'{start_date.strftime("%Y-%m-%dT%H:%M:%SZ")}/{end_date.strftime("%Y-%m-%dT%H:%M:%SZ")}'
         cpu_metrics = self.monitor_operations.get_resource_metrics(resource_id=resource_id,
                                                                    metricnames='Percentage CPU',
                                                                    aggregation='Average',
@@ -218,7 +218,7 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         start_date, end_date = Utils.get_start_and_end_datetime(days=days)
-        timespan = f'{start_date.isoformat()}/{end_date.isoformat()}'
+        timespan = f'{start_date.strftime("%Y-%m-%dT%H:%M:%SZ")}/{end_date.strftime("%Y-%m-%dT%H:%M:%SZ")}'
         network_in_metrics = self.monitor_operations.get_resource_metrics(resource_id=resource_id,
                                                                           metricnames='Network In Total',
                                                                           aggregation='Average',
@@ -238,7 +238,7 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         start_date, end_date = Utils.get_start_and_end_datetime(days=days)
-        timespan = f'{start_date.isoformat()}/{end_date.isoformat()}'
+        timespan = f'{start_date.strftime("%Y-%m-%dT%H:%M:%SZ")}/{end_date.strftime("%Y-%m-%dT%H:%M:%SZ")}'
         network_out_metrics = self.monitor_operations.get_resource_metrics(resource_id=resource_id,
                                                                            metricnames='Network Out Total',
                                                                            aggregation='Average',


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [x] dependencies

## Description
Azure Monitor API requires timespan to use 'Z' suffix for UTC timezone instead of '+00:00' offset. Changed from datetime.isoformat() to strftime('%Y-%m-%dT%H:%M:%SZ') to match Azure's expected ISO 8601 format.

This fixes the BadRequest error: "Detected invalid time interval input" that was occurring in instance_idle and unused_nat_gateway policies.

## For security reasons, all pull requests need to be approved first before running any automated CI
