### PR TITLE
Fix IBM Schematics API compatibility issue

### DIFF
--- a/cloud_governance/common/clouds/ibm/developer_tools/schematic_operations.py
+++ b/cloud_governance/common/clouds/ibm/developer_tools/schematic_operations.py
@@ -34,22 +34,31 @@ class SchematicOperations(IBMAuthenticator):
     def get_supported_locations(self):
         """
         This method lists supported locations
+        DEPRECATED: list_locations() was removed from IBM Schematics SDK
         :return:
         """
-        response = self.__client.list_locations().get_result()
-        return response['locations']
+        # Method no longer available in IBM Schematics SDK
+        # Use known regions in get_all_workspaces() instead
+        raise NotImplementedError("list_locations() is no longer available in IBM Schematics SDK")
 
     def get_all_workspaces(self):
         """
         This method lists all available schematics workspaces
         :return:
         """
-        locations = self.get_supported_locations()
+        # list_locations() was removed from IBM Schematics SDK
+        # Use known IBM Cloud regions instead
+        known_regions = ['us-south', 'us-east', 'eu-de', 'eu-gb']
         resources_list = {}
-        for location in locations:
-            region = location['region']
-            geography_code = location['geography_code']
-            self.set_service_url(region)
-            if geography_code not in resources_list:
-                resources_list[geography_code] = self.get_workspaces()
+
+        for region in known_regions:
+            try:
+                self.set_service_url(region)
+                workspaces = self.get_workspaces()
+                if workspaces:
+                    resources_list[region] = workspaces
+            except Exception:
+                # Skip regions where schematics is not available or no access
+                continue
+
         return resources_list

--- a/cloud_governance/common/clouds/ibm/developer_tools/schematic_operations.py
+++ b/cloud_governance/common/clouds/ibm/developer_tools/schematic_operations.py
@@ -45,11 +45,13 @@ class SchematicOperations(IBMAuthenticator):
         """
         This method lists all available schematics workspaces
         :return:
+        :raises: RuntimeError if unable to query any region
         """
         # list_locations() was removed from IBM Schematics SDK
         # Use known IBM Cloud regions instead
         known_regions = ['us-south', 'us-east', 'eu-de', 'eu-gb']
         resources_list = {}
+        failed_regions = []
 
         for region in known_regions:
             try:
@@ -57,8 +59,18 @@ class SchematicOperations(IBMAuthenticator):
                 workspaces = self.get_workspaces()
                 if workspaces:
                     resources_list[region] = workspaces
-            except Exception:
-                # Skip regions where schematics is not available or no access
+            except Exception as exc:
+                # Track failed regions for debugging
+                failed_regions.append((region, str(exc)))
                 continue
+
+        # If all regions failed, raise error instead of returning empty dict
+        if not resources_list and len(failed_regions) == len(known_regions):
+            failed_details = '; '.join(f"{region}: {error}" for region, error in failed_regions)
+            raise RuntimeError(
+                f"Unable to list Schematics workspaces in any region. "
+                f"All {len(known_regions)} regions failed. "
+                f"Check credentials and permissions. Details: {failed_details}"
+            )
 
         return resources_list


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
The list_locations() method was removed from IBM Schematics SDK. Replace dynamic location discovery with hardcoded known IBM Cloud regions. Fixes AttributeError: 'SchematicsV1' object has no attribute 'list_locations'

## For security reasons, all pull requests need to be approved first before running any automated CI

_Assisted-by: Cursor_