### PR TITLE
Fix IBM weekly cost_over_usage ElasticSearch configuration

### DIFF
--- a/jenkins/clouds/ibm/weekly/cost_over_usage/Jenkinsfile
+++ b/jenkins/clouds/ibm/weekly/cost_over_usage/Jenkinsfile
@@ -6,11 +6,15 @@ pipeline {
         docker {
             label 'cloud-governance-worker'
             image 'quay.io/rh_perfscale/fedora38-podman:latest'
-            args  '-u root -v /etc/postfix/main.cf:/etc/postfix/main.cf --privileged'
+            args  '--entrypoint="" -u root -v /etc/postfix/main.cf:/etc/postfix/main.cf --privileged'
         }
     }
     environment {
         QUAY_CLOUD_GOVERNANCE_REPOSITORY = credentials('QUAY_CLOUD_GOVERNANCE_REPOSITORY')
+        ES_HOST = credentials('cloud-governance-es-host')
+        ES_PORT = credentials('cloud-governance-es-port')
+        ES_USER = credentials('cloud-governance-es-user')
+        ES_PASSWORD = credentials('cloud-governance-es-password')
         USAGE_REPORTS_APIKEY = credentials('cloud-governance-ibm-service-id-performance-scale')
         IBM_ACCOUNT_ID = credentials('cloud-governance-ibm-account-id-performance-scale')
         contact1 = "ebattat@redhat.com"

--- a/jenkins/clouds/ibm/weekly/cost_over_usage/run_policies.py
+++ b/jenkins/clouds/ibm/weekly/cost_over_usage/run_policies.py
@@ -2,6 +2,10 @@ import os
 
 USAGE_REPORTS_APIKEY = os.environ['USAGE_REPORTS_APIKEY']
 IBM_ACCOUNT_ID = os.environ['IBM_ACCOUNT_ID']
+ES_HOST = os.environ.get('ES_HOST', '')
+ES_PORT = os.environ.get('ES_PORT', '')
+ES_USER = os.environ.get('ES_USER', '')
+ES_PASSWORD = os.environ.get('ES_PASSWORD', '')
 TO_MAIL = ['natashba@redhat.com']
 CC_MAIL = ['yinsong@redhat.com', 'ebattat@redhat.com', 'pragchau@redhat.com']
 USAGE_REPORTS_AUTHTYPE = 'iam'
@@ -9,4 +13,4 @@ MAXIMUM_THRESHOLD = 1000
 QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ['QUAY_CLOUD_GOVERNANCE_REPOSITORY']
 
 os.system(
-    f"""podman run --rm --name cloud-governance --net=host -e policy="ibm_cost_over_usage" -e account="IBM-PERF" -e IBM_ACCOUNT_ID="{IBM_ACCOUNT_ID}" -e to_mail="{TO_MAIL}" -e cc_mail="{CC_MAIL}" -e USAGE_REPORTS_APIKEY="{USAGE_REPORTS_APIKEY}" -e USAGE_REPORTS_AUTHTYPE="{USAGE_REPORTS_AUTHTYPE}" -e MAXIMUM_THRESHOLD="{MAXIMUM_THRESHOLD}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+    f"""podman run --rm --name cloud-governance --net=host -e policy="ibm_cost_over_usage" -e account="IBM-PERF" -e IBM_ACCOUNT_ID="{IBM_ACCOUNT_ID}" -e to_mail="{TO_MAIL}" -e cc_mail="{CC_MAIL}" -e USAGE_REPORTS_APIKEY="{USAGE_REPORTS_APIKEY}" -e USAGE_REPORTS_AUTHTYPE="{USAGE_REPORTS_AUTHTYPE}" -e MAXIMUM_THRESHOLD="{MAXIMUM_THRESHOLD}" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}" -e es_user="{ES_USER}" -e es_password="{ES_PASSWORD}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Added missing ElasticSearch credentials to enable data upload to ES/OpenSearch.

Changes:
- Added ES_HOST, ES_PORT, ES_USER, ES_PASSWORD environment variables to Jenkinsfile
- Updated run_policies.py to read ES credentials and pass them to podman container
- Fixed Docker entrypoint issue by adding --entrypoint="" flag

This resolves the warning: "ElasticSearch/OpenSearch not configured (es_host=, es_port=). Policy will run without ES upload."

## For security reasons, all pull requests need to be approved first before running any automated CI

_Assisted-by: Cursor_