### PR TITLE
Fix datetime parsing errors with timezone offsets

### DIFF
--- a/cloud_governance/common/clouds/aws/price/price.py
+++ b/cloud_governance/common/clouds/aws/price/price.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from time import strftime
 
 import json
+import re
 from pathlib import Path
 
 import botocore
@@ -106,10 +107,13 @@ class AWSPrice:
             if isinstance(ec2_lanuch_time, datetime):
                 d1 = ec2_lanuch_time.replace(tzinfo=None)
             else:
-                launch_time_str = str(ec2_lanuch_time).split('.')[0].replace('Z', '+00:00')
-                if '+' not in launch_time_str:
+                # Remove fractional seconds while preserving timezone offset
+                launch_time_str = re.sub(r'\.\d+', '', str(ec2_lanuch_time)).replace('Z', '+00:00')
+                # Check if timezone offset exists (handles both + and - offsets)
+                if not re.search(r'[+-]\d{2}:\d{2}$', launch_time_str):
                     launch_time_str += '+00:00'
-                d1 = datetime.strptime(launch_time_str, "%Y-%m-%dT%H:%M:%S+00:00")
+                # Parse with timezone and then remove it for consistent naive datetime
+                d1 = datetime.strptime(launch_time_str, "%Y-%m-%dT%H:%M:%S%z").replace(tzinfo=None)
             d2 = datetime.strptime(strftime("%Y-%m-%dT%H:%M:%S+00:00"), "%Y-%m-%dT%H:%M:%S+00:00")
             diff = d2 - d1
             diff_in_hours = diff.total_seconds() / 3600

--- a/cloud_governance/common/clouds/aws/price/price.py
+++ b/cloud_governance/common/clouds/aws/price/price.py
@@ -103,7 +103,13 @@ class AWSPrice:
             except Exception as err:
                 return 'NA'
             ec2_lanuch_time = item_data['LaunchTime']
-            d1 = datetime.strptime(ec2_lanuch_time, "%Y-%m-%dT%H:%M:%S+00:00")
+            if isinstance(ec2_lanuch_time, datetime):
+                d1 = ec2_lanuch_time.replace(tzinfo=None)
+            else:
+                launch_time_str = str(ec2_lanuch_time).split('.')[0].replace('Z', '+00:00')
+                if '+' not in launch_time_str:
+                    launch_time_str += '+00:00'
+                d1 = datetime.strptime(launch_time_str, "%Y-%m-%dT%H:%M:%S+00:00")
             d2 = datetime.strptime(strftime("%Y-%m-%dT%H:%M:%S+00:00"), "%Y-%m-%dT%H:%M:%S+00:00")
             diff = d2 - d1
             diff_in_hours = diff.total_seconds() / 3600

--- a/cloud_governance/common/jira/jira_operations.py
+++ b/cloud_governance/common/jira/jira_operations.py
@@ -127,7 +127,8 @@ class JiraOperations:
                                 description_dict['Project'] = description_dict.get('Otherproductsbeingtested')
                             if not description_dict['Project']:
                                 description_dict['Project'] = description_dict.get('Explanationof"Other"secondaryproduct')
-                    description_dict['TicketOpenedDate'] = datetime.strptime(issue_data.get('fields').get('created').split('.')[0], "%Y-%m-%dT%H:%M:%S")
+                    created_str = issue_data.get('fields').get('created').split('.')[0].split('+')[0].split('Z')[0]
+                    description_dict['TicketOpenedDate'] = datetime.strptime(created_str, "%Y-%m-%dT%H:%M:%S")
                     description_dict['JiraStatus'] = issue_data['fields']['status']['name']
                     self.cache_ticket_description(ticket_id=ticket_id, ticket_description=description_dict)
                     return description_dict
@@ -145,7 +146,8 @@ class JiraOperations:
             if '[Clouds]' in issue['fields']['summary']:
                 ticket_id = issue.get('key')
                 description = self.beautify_issue_description(issue['fields']['description'])
-                description['TicketOpenedDate'] = datetime.strptime(issue.get('fields').get('created').split('.')[0], "%Y-%m-%dT%H:%M:%S")
+                created_str = issue.get('fields').get('created').split('.')[0].split('+')[0].split('Z')[0]
+                description['TicketOpenedDate'] = datetime.strptime(created_str, "%Y-%m-%dT%H:%M:%S")
                 ticket_ids[ticket_id] = description.get('Region')
         return ticket_ids
 
@@ -231,7 +233,8 @@ class JiraOperations:
             if '[Clouds]' in issue['fields']['summary']:
                 ticket_id = issue.get('key')
                 description = self.beautify_issue_description(issue['fields']['description'])
-                description['TicketOpenedDate'] = datetime.strptime(issue.get('fields').get('created').split('.')[0], "%Y-%m-%dT%H:%M:%S")
+                created_str = issue.get('fields').get('created').split('.')[0].split('+')[0].split('Z')[0]
+                description['TicketOpenedDate'] = datetime.strptime(created_str, "%Y-%m-%dT%H:%M:%S")
                 ticket_ids[ticket_id] = description
         return ticket_ids
 

--- a/tests/unittest/cloud_governance/common/clouds/aws/price/test_price.py
+++ b/tests/unittest/cloud_governance/common/clouds/aws/price/test_price.py
@@ -69,3 +69,93 @@ def test_ec2_price(mock_get_boto3_client):
     }
     ec2_type_cost = __aws_price.get_ec2_price(resource="ec2", item_data=item_data)
     assert ec2_type_cost >= 0
+
+
+@patch("cloud_governance.common.clouds.aws.price.price.get_boto3_client")
+def test_ec2_price_with_datetime_object(mock_get_boto3_client):
+    """Test EC2 pricing with LaunchTime as datetime object."""
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
+    mock_client = MagicMock()
+    mock_client.get_products.return_value = _make_price_list_response("0.0116")
+    mock_get_boto3_client.return_value = mock_client
+
+    __aws_price = AWSPrice()
+    item_data = {
+        "InstanceType": "t2.micro",
+        "LaunchTime": datetime.datetime.now(),
+        "State": {"Name": "running"},
+    }
+    ec2_type_cost = __aws_price.get_ec2_price(resource="ec2", item_data=item_data)
+    assert ec2_type_cost >= 0
+
+
+@patch("cloud_governance.common.clouds.aws.price.price.get_boto3_client")
+def test_ec2_price_with_fractional_seconds(mock_get_boto3_client):
+    """Test EC2 pricing with LaunchTime containing fractional seconds."""
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
+    mock_client = MagicMock()
+    mock_client.get_products.return_value = _make_price_list_response("0.0116")
+    mock_get_boto3_client.return_value = mock_client
+
+    __aws_price = AWSPrice()
+    item_data = {
+        "InstanceType": "t2.micro",
+        "LaunchTime": "2024-01-15T12:30:45.123456+00:00",
+        "State": {"Name": "running"},
+    }
+    ec2_type_cost = __aws_price.get_ec2_price(resource="ec2", item_data=item_data)
+    assert ec2_type_cost >= 0
+
+
+@patch("cloud_governance.common.clouds.aws.price.price.get_boto3_client")
+def test_ec2_price_with_negative_timezone(mock_get_boto3_client):
+    """Test EC2 pricing with LaunchTime containing negative timezone offset."""
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
+    mock_client = MagicMock()
+    mock_client.get_products.return_value = _make_price_list_response("0.0116")
+    mock_get_boto3_client.return_value = mock_client
+
+    __aws_price = AWSPrice()
+    item_data = {
+        "InstanceType": "t2.micro",
+        "LaunchTime": "2024-01-15T12:30:45-05:00",
+        "State": {"Name": "running"},
+    }
+    ec2_type_cost = __aws_price.get_ec2_price(resource="ec2", item_data=item_data)
+    assert ec2_type_cost >= 0
+
+
+@patch("cloud_governance.common.clouds.aws.price.price.get_boto3_client")
+def test_ec2_price_with_z_timezone(mock_get_boto3_client):
+    """Test EC2 pricing with LaunchTime using Z (Zulu time) notation."""
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
+    mock_client = MagicMock()
+    mock_client.get_products.return_value = _make_price_list_response("0.0116")
+    mock_get_boto3_client.return_value = mock_client
+
+    __aws_price = AWSPrice()
+    item_data = {
+        "InstanceType": "t2.micro",
+        "LaunchTime": "2024-01-15T12:30:45Z",
+        "State": {"Name": "running"},
+    }
+    ec2_type_cost = __aws_price.get_ec2_price(resource="ec2", item_data=item_data)
+    assert ec2_type_cost >= 0
+
+
+@patch("cloud_governance.common.clouds.aws.price.price.get_boto3_client")
+def test_ec2_price_with_fractional_seconds_and_offset(mock_get_boto3_client):
+    """Test EC2 pricing with LaunchTime containing both fractional seconds and timezone offset."""
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
+    mock_client = MagicMock()
+    mock_client.get_products.return_value = _make_price_list_response("0.0116")
+    mock_get_boto3_client.return_value = mock_client
+
+    __aws_price = AWSPrice()
+    item_data = {
+        "InstanceType": "t2.micro",
+        "LaunchTime": "2024-01-15T12:30:45.999999+05:30",
+        "State": {"Name": "running"},
+    }
+    ec2_type_cost = __aws_price.get_ec2_price(resource="ec2", item_data=item_data)
+    assert ec2_type_cost >= 0


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [x] dependencies

## Description
Resolved 4 instances of "unconverted data remains: +00:00" errors:
- jira_operations.py: Strip timezone info when parsing Jira created timestamps (3 locations)
- price.py: Handle both datetime objects and strings with microseconds for EC2 LaunchTime

The fixes properly remove timezone offsets and milliseconds before parsing to prevent strptime format mismatches.

## For security reasons, all pull requests need to be approved first before running any automated CI

_Assisted-by: Cursor_