### PR TITLE
Fix unconverted timezone offset error in CRO run tracking and mail alerts

### DIFF
--- a/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/cost_over_usage.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/cost_over_usage.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 import typeguard
 
 from cloud_governance.cloud_resource_orchestration.utils.constant_variables import DATE_FORMAT
+from cloud_governance.cloud_resource_orchestration.utils.common_operations import parse_iso_datetime
 from cloud_governance.cloud_resource_orchestration.utils.elastic_search_queries import ElasticSearchQueries
 from cloud_governance.common.clouds.aws.cost_explorer.cost_explorer_operations import CostExplorerOperations
 from cloud_governance.common.clouds.aws.ec2.ec2_operations import EC2Operations
@@ -294,7 +295,7 @@ class CostOverUsage:
             last_send_date = last_alert.get('_source').get('timestamp')
             alert_number = last_alert.get('_source').get('Alert', 0)
             current_date = datetime.now(tz=timezone.utc).date()
-            last_send_date = datetime.strptime(last_send_date, self.TIMESTAMP_DATE_FORMAT).date()
+            last_send_date = parse_iso_datetime(last_send_date).date()
             days = (current_date - last_send_date).days
             if days % self.SEND_ALERT_DAY == 0 and last_send_date != current_date:
                 return True, alert_number

--- a/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/run_cro.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/run_cro.py
@@ -7,6 +7,7 @@ from cloud_governance.cloud_resource_orchestration.clouds.aws.ec2.cost_over_usag
 from cloud_governance.cloud_resource_orchestration.clouds.aws.ec2.monitor_cro_instances import MonitorCROInstances
 from cloud_governance.cloud_resource_orchestration.clouds.aws.ec2.aws_monitor_tickets import AWSMonitorTickets
 from cloud_governance.cloud_resource_orchestration.clouds.aws.ec2.tag_cro_instances import TagCROInstances
+from cloud_governance.cloud_resource_orchestration.utils.common_operations import parse_iso_datetime
 from cloud_governance.common.logger.init_logger import logger
 from cloud_governance.common.logger.logger_time_stamp import logger_time_stamp
 from cloud_governance.main.environment_variables import environment_variables
@@ -38,7 +39,7 @@ class RunCRO:
             source = es_data.get('_source')
             last_run_time = source.get(f'last_run_{self.account.lower()}')
             if last_run_time:
-                last_updated_time = datetime.strptime(last_run_time, "%Y-%m-%dT%H:%M:%S.%f").date()
+                last_updated_time = parse_iso_datetime(last_run_time).date()
                 if last_updated_time == datetime.now(tz=timezone.utc).date():
                     first_run = False
         self.__environment_variables_dict.update({'CRO_FIRST_RUN': first_run})

--- a/cloud_governance/cloud_resource_orchestration/common/run_cro.py
+++ b/cloud_governance/cloud_resource_orchestration/common/run_cro.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timezone
 
 from cloud_governance.cloud_resource_orchestration.common.cro_object import CroObject
-from cloud_governance.cloud_resource_orchestration.utils.common_operations import string_equal_ignore_case
+from cloud_governance.cloud_resource_orchestration.utils.common_operations import string_equal_ignore_case, \
+    parse_iso_datetime
 from cloud_governance.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
 from cloud_governance.common.logger.init_logger import logger
 from cloud_governance.common.logger.logger_time_stamp import logger_time_stamp
@@ -55,7 +56,7 @@ class RunCRO:
                 source = es_data.get('_source')
                 last_run_time = source.get(f'last_run_{self.__account.lower()}')
                 if last_run_time:
-                    last_updated_time = datetime.strptime(last_run_time, "%Y-%m-%dT%H:%M:%S.%f").date()
+                    last_updated_time = parse_iso_datetime(last_run_time).date()
                     if last_updated_time == datetime.now(tz=timezone.utc).date():
                         first_run = False
             self.__environment_variables_dict.update({'CRO_FIRST_RUN': first_run})

--- a/cloud_governance/cloud_resource_orchestration/utils/common_operations.py
+++ b/cloud_governance/cloud_resource_orchestration/utils/common_operations.py
@@ -1,6 +1,27 @@
+import re
+from datetime import datetime
 from typing import Union
 
 from cloud_governance.main.environment_variables import environment_variables
+
+_ISO_DATETIME_OFFSET_RE = re.compile(r'[+-]\d{2}:\d{2}$')
+
+
+def parse_iso_datetime(value: str) -> datetime:
+    """
+    This method parses an ISO 8601 datetime string, tolerating fractional seconds and a
+    trailing timezone offset (e.g. '+00:00', '-05:00') or 'Z' suffix.
+    Elasticsearch/OpenSearch clients serialize stored python datetime objects back to
+    strings like '2026-07-09T13:00:23.548397+00:00', which plain strptime formats such as
+    '%Y-%m-%dT%H:%M:%S.%f' cannot parse (raises "unconverted data remains: +00:00").
+    The returned datetime is naive (tzinfo stripped) for easy comparison with naive dates.
+    :param value:
+    :return:
+    """
+    normalized = re.sub(r'\.\d+', '', str(value)).replace('Z', '+00:00')
+    if _ISO_DATETIME_OFFSET_RE.search(normalized):
+        return datetime.strptime(normalized, '%Y-%m-%dT%H:%M:%S%z').replace(tzinfo=None)
+    return datetime.strptime(normalized, '%Y-%m-%dT%H:%M:%S')
 
 
 def string_equal_ignore_case(value1: str, value2: str, *args) -> bool:

--- a/tests/unittest/cloud_governance/cloud_resource_orchestration/common/test_run_cro.py
+++ b/tests/unittest/cloud_governance/cloud_resource_orchestration/common/test_run_cro.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock, patch
+
+from cloud_governance.main.environment_variables import environment_variables
+
+
+@patch('cloud_governance.cloud_resource_orchestration.common.run_cro.CroObject')
+@patch('cloud_governance.cloud_resource_orchestration.common.run_cro.ElasticSearchOperations')
+def test_send_cro_alerts_handles_es_stored_offset_datetime(mock_es_operations_cls, mock_cro_object_cls):
+    """
+    Regression test: Elasticsearch returns the previously stored `last_run_<account>`
+    timestamp as an ISO string with a timezone offset (e.g. '...+00:00'), since the
+    ES client serializes stored `datetime.now(tz=timezone.utc)` objects via isoformat().
+    RunCRO must parse this without raising "unconverted data remains: +00:00", and must
+    still run the cost-over-usage/ticket-monitoring flow when the stored date differs
+    from today.
+    """
+    from cloud_governance.cloud_resource_orchestration.common.run_cro import RunCRO
+
+    environment_variables.environment_variables_dict['account'] = 'perf-dept'
+    environment_variables.environment_variables_dict['PUBLIC_CLOUD_NAME'] = 'AWS'
+
+    mock_es_operations = MagicMock()
+    mock_es_operations.get_es_data_by_id.return_value = {
+        '_source': {'last_run_perf-dept': '2020-01-01T13:00:23.548397+00:00'}
+    }
+    mock_es_operations.verify_elastic_index_doc_id.return_value = True
+    mock_es_operations_cls.return_value = mock_es_operations
+
+    mock_cost_over_usage = MagicMock()
+    mock_cost_over_usage.run.return_value = ['user1']
+    mock_monitor_tickets = MagicMock()
+    mock_cro_reports = MagicMock()
+
+    mock_cro_object = MagicMock()
+    mock_cro_object.cost_over_usage.return_value = mock_cost_over_usage
+    mock_cro_object.collect_cro_reports.return_value = mock_cro_reports
+    mock_cro_object.monitor_tickets.return_value = mock_monitor_tickets
+    mock_cro_object_cls.return_value = mock_cro_object
+
+    run_cro = RunCRO()
+    run_cro.run()
+
+    mock_cost_over_usage.run.assert_called_once()
+    mock_monitor_tickets.run.assert_called_once()
+    mock_cro_reports.update_in_progress_ticket_cost.assert_called_once()
+
+
+@patch('cloud_governance.cloud_resource_orchestration.common.run_cro.CroObject')
+@patch('cloud_governance.cloud_resource_orchestration.common.run_cro.ElasticSearchOperations')
+def test_send_cro_alerts_skips_when_already_run_today(mock_es_operations_cls, mock_cro_object_cls):
+    """When the stored last_run timestamp is today (still with a timezone offset), the
+    alert/ticket-monitoring flow should be skipped rather than re-run."""
+    from datetime import datetime, timezone
+
+    from cloud_governance.cloud_resource_orchestration.common.run_cro import RunCRO
+
+    environment_variables.environment_variables_dict['account'] = 'perf-dept'
+    environment_variables.environment_variables_dict['PUBLIC_CLOUD_NAME'] = 'AWS'
+
+    today_iso = datetime.now(tz=timezone.utc).isoformat()
+
+    mock_es_operations = MagicMock()
+    mock_es_operations.get_es_data_by_id.return_value = {
+        '_source': {'last_run_perf-dept': today_iso}
+    }
+    mock_es_operations.verify_elastic_index_doc_id.return_value = True
+    mock_es_operations_cls.return_value = mock_es_operations
+
+    mock_cost_over_usage = MagicMock()
+    mock_monitor_tickets = MagicMock()
+    mock_cro_reports = MagicMock()
+
+    mock_cro_object = MagicMock()
+    mock_cro_object.cost_over_usage.return_value = mock_cost_over_usage
+    mock_cro_object.collect_cro_reports.return_value = mock_cro_reports
+    mock_cro_object.monitor_tickets.return_value = mock_monitor_tickets
+    mock_cro_object_cls.return_value = mock_cro_object
+
+    run_cro = RunCRO()
+    run_cro.run()
+
+    mock_cost_over_usage.run.assert_not_called()
+    mock_monitor_tickets.run.assert_not_called()
+    mock_cro_reports.update_in_progress_ticket_cost.assert_not_called()

--- a/tests/unittest/cloud_governance/cloud_resource_orchestration/utils/test_common_operations.py
+++ b/tests/unittest/cloud_governance/cloud_resource_orchestration/utils/test_common_operations.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+import pytest
+
+from cloud_governance.cloud_resource_orchestration.utils.common_operations import parse_iso_datetime
+
+
+def test_parse_iso_datetime_plain():
+    """Plain ISO datetime string without fractional seconds or timezone offset."""
+    assert parse_iso_datetime('2026-07-09T13:00:23') == datetime(2026, 7, 9, 13, 0, 23)
+
+
+def test_parse_iso_datetime_with_utc_offset():
+    """Elasticsearch/OpenSearch serializes a stored `datetime.now(tz=timezone.utc)` back as this format."""
+    assert parse_iso_datetime('2026-07-09T13:00:23.548397+00:00') == datetime(2026, 7, 9, 13, 0, 23)
+
+
+def test_parse_iso_datetime_with_negative_offset():
+    assert parse_iso_datetime('2026-07-09T13:00:23.123456-05:00') == datetime(2026, 7, 9, 13, 0, 23)
+
+
+def test_parse_iso_datetime_with_z_suffix():
+    assert parse_iso_datetime('2026-07-09T13:00:23.123456Z') == datetime(2026, 7, 9, 13, 0, 23)
+
+
+def test_parse_iso_datetime_with_offset_no_fractional_seconds():
+    assert parse_iso_datetime('2026-07-09T13:00:23+00:00') == datetime(2026, 7, 9, 13, 0, 23)
+
+
+def test_parse_iso_datetime_with_fractional_seconds_no_offset():
+    assert parse_iso_datetime('2026-07-09T13:00:23.548397') == datetime(2026, 7, 9, 13, 0, 23)
+
+
+def test_parse_iso_datetime_invalid_raises():
+    with pytest.raises(ValueError):
+        parse_iso_datetime('not-a-datetime')


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [x] dependencies

## Description
Elasticsearch serializes stored datetime.now(tz=timezone.utc) values back as ISO strings with a trailing offset (e.g. '...+00:00'), but RunCRO and CostOverUsage.get_last_mail_alert_status parsed them with strptime formats missing %z, raising "unconverted data remains: +00:00" and silently skipping the cost-over-usage/ticket-monitoring flow every run. Added a shared parse_iso_datetime helper that tolerates fractional seconds and both +/- timezone offsets, and use it in both call sites.

Related to : https://github.com/redhat-performance/cloud-governance/pull/1010


## For security reasons, all pull requests need to be approved first before running any automated CI
_Assisted-by: Cursor_