### PR TITLE
Fix zombie_cluster_resource false positive detection for CAPA clusters

### DIFF
--- a/cloud_governance/common/clouds/aws/utils/utils.py
+++ b/cloud_governance/common/clouds/aws/utils/utils.py
@@ -125,7 +125,7 @@ class Utils:
                     return True, tag.get('Key')
             else:
                 if tags:
-                    for tag in tags:
-                        if tag.get('Key').startswith(prefix):
-                            return True, tag.get('Key')
+                    for t in tags:
+                        if t.get('Key').startswith(prefix):
+                            return True, t.get('Key')
         return False, None

--- a/cloud_governance/policy/aws/zombie_cluster_resource.py
+++ b/cloud_governance/policy/aws/zombie_cluster_resource.py
@@ -30,6 +30,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         self.delete_s3_resource = DeleteS3Resources(s3_client=self.s3_client, s3_resource=self.s3_resource)
         self.ec2_operations = EC2Operations(region=region)
         self.__get_details_resource_list = Utils().get_details_resource_list
+        self._vpcs_with_instances = set()
 
     def all_cluster_instance(self):
         """
@@ -65,6 +66,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         """
         instances_list = []
         result_instance = {}
+        self._vpcs_with_instances = set()
         ec2s_data = self.ec2_operations.get_instances()
         for items in ec2s_data:
             if items.get('Instances'):
@@ -72,6 +74,9 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         for instance in instances_list:
             for item in instance:
                 instance_id = item['InstanceId']
+                vpc_id = item.get('VpcId')
+                if vpc_id:
+                    self._vpcs_with_instances.add(vpc_id)
                 ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                            tags=item.get('Tags', []))
                 if ok:
@@ -104,10 +109,6 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
                         if self.cluster_tag and self.cluster_tag == tag['Key']:
                             result_resources_key_id[resource_id] = tag['Key']
                             break
-                        else:
-                            if self.resource_name and self.resource_name == tag['Value']:
-                                result_resources_key_id[resource_id] = tag['Key']
-                                break
         return result_resources_key_id
 
     def __extract_vpc_id_from_resource_data(self, zombie_id: str, resource_data: list, input_tag: str,
@@ -149,17 +150,47 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
                 ids.append(resource.get(output_tag))
         return ids
 
+    def __extract_cluster_name(self, tag_key: str):
+        """
+        This method extracts the cluster name from a full tag key by stripping the prefix.
+        e.g. 'kubernetes.io/cluster/my-cluster' -> 'my-cluster'
+             'sigs.k8s.io/cluster-api-provider-aws/cluster/my-cluster' -> 'my-cluster'
+        """
+        if not tag_key:
+            return ''
+        for prefix in self.cluster_prefix:
+            if tag_key.startswith(prefix):
+                name = tag_key[len(prefix):].lstrip('/')
+                return name
+        return tag_key
+
+    def _filter_zombies_by_vpc(self, zombies: dict, resource_data: list, vpc_key: str = 'VpcId'):
+        """
+        This method filters out zombies whose VPC has running instances (F2 safety net).
+        """
+        if not self._vpcs_with_instances:
+            return zombies
+        filtered = {}
+        for zombie_id, cluster_tag in zombies.items():
+            vpc_id = self.__extract_vpc_id_from_resource_data(
+                zombie_id=zombie_id, resource_data=resource_data, input_tag=vpc_key)
+            if vpc_id not in self._vpcs_with_instances:
+                filtered[zombie_id] = cluster_tag
+        return filtered
+
     def __get_zombie_resources(self, exist_resources: dict):
         """
         This method filter zombie resource, meaning no active instance for this cluster
         """
         zombie_resources = {}
-        zombies_values = set(exist_resources.values()) - set(self._cluster_instance().values())
+        instance_cluster_names = {self.__extract_cluster_name(v)
+                                  for v in self._cluster_instance().values()}
+        instance_cluster_names.discard('')
 
-        for zombie_value in zombies_values:
-            for key, value in exist_resources.items():
-                if zombie_value == value:
-                    zombie_resources[key] = value
+        for key, value in exist_resources.items():
+            resource_cluster_name = self.__extract_cluster_name(value)
+            if resource_cluster_name and resource_cluster_name not in instance_cluster_names:
+                zombie_resources[key] = value
 
         return zombie_resources
 
@@ -168,12 +199,14 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         This method filter zombie resource, meaning no active instance for this cluster in all regions
         """
         zombie_resources = {}
-        zombies_values = set(exist_resources.values()) - set(self.all_cluster_instance().values())
+        instance_cluster_names = {self.__extract_cluster_name(v)
+                                  for v in self.all_cluster_instance().values()}
+        instance_cluster_names.discard('')
 
-        for zombie_value in zombies_values:
-            for key, value in exist_resources.items():
-                if zombie_value == value:
-                    zombie_resources[key] = value
+        for key, value in exist_resources.items():
+            resource_cluster_name = self.__extract_cluster_name(value)
+            if resource_cluster_name and resource_cluster_name not in instance_cluster_names:
+                zombie_resources[key] = value
         return zombie_resources
 
     def zombie_cluster_volume(self, vpc_id: str = '', cluster_tag_vpc: str = ''):
@@ -279,9 +312,20 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
             if vpcs:
                 vpc = vpcs[0]
                 if vpc.get('Tags'):
-                    for tag in vpc.get('Tags'):
-                        if cluster_tag in tag.get('Key'):
-                            return tag.get('Key')
+                    if cluster_tag:
+                        search_name = self.__extract_cluster_name(cluster_tag)
+                        if not search_name:
+                            return ''
+                        for tag in vpc.get('Tags'):
+                            tag_name = self.__extract_cluster_name(tag.get('Key'))
+                            if tag_name and tag_name == search_name:
+                                return tag.get('Key')
+                    else:
+                        for tag in vpc.get('Tags'):
+                            ok, _ = Utils.is_cluster_resource(
+                                cluster_prefix=self.cluster_prefix, tag=tag)
+                            if ok:
+                                return tag.get('Key')
         return ''
 
     def __get_zombies_by_vpc_id(self, vpc_id: str, resources: list, output_tag: str, cluster_tag: str = '',
@@ -327,6 +371,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         security_groups = self.ec2_operations.get_security_groups()
         exist_security_group = self.__get_cluster_resources(resources_list=security_groups, input_resource_id='GroupId')
         zombies = self.__get_zombie_resources(exist_security_group)
+        zombies = self._filter_zombies_by_vpc(zombies, security_groups, vpc_key='GroupId')
         if vpc_id and not zombies:
             zombies = self.__get_zombies_by_vpc_id(vpc_id=vpc_id, resources=security_groups, output_tag='GroupId',
                                                    cluster_tag=cluster_tag_vpc)
@@ -373,7 +418,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
                                                             input_resource_id='AllocationId')
         zombies_ass = self.__get_zombie_resources(exist_elastic_ip_ass)
         zombies_all = self.__get_zombie_resources(exist_elastic_ip_all)
-        resources_ass = self._get_tags_of_zombie_resources(resources=elastic_ips_data, resource_id_name='AllocationId',
+        resources_ass = self._get_tags_of_zombie_resources(resources=elastic_ips_data, resource_id_name='AssociationId',
                                                            zombies=zombies_ass, aws_service='ec2')
         resources_all = self._get_tags_of_zombie_resources(resources=elastic_ips_data, resource_id_name='AllocationId',
                                                            zombies=zombies_all, aws_service='ec2')
@@ -402,7 +447,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
                     if self._force_delete and self.delete:
                         self.delete_ec2_resource.delete_zombie_resource(resource='elastic_ip', resource_id=zombie,
                                                                         cluster_tag=cluster_tag)
-        zombies = {**zombies_all}
+        zombies = {**zombies_ass, **zombies_all}
         return zombies, cluster_left_out_days
 
     def zombie_cluster_network_interface(self, vpc_id: str = '', cluster_tag_vpc: str = ''):
@@ -413,6 +458,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         exist_network_interface = self.__get_cluster_resources(resources_list=network_interfaces_data,
                                                                input_resource_id='NetworkInterfaceId', tags='TagSet')
         zombies = self.__get_zombie_resources(exist_network_interface)
+        zombies = self._filter_zombies_by_vpc(zombies, network_interfaces_data, vpc_key='NetworkInterfaceId')
         if not zombies and vpc_id:
             zombies = self.__get_zombies_by_vpc_id(vpc_id=vpc_id, resources=network_interfaces_data,
                                                    output_tag='NetworkInterfaceId', tags='TagSet',
@@ -553,6 +599,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         vpcs_data = self.ec2_operations.get_vpcs()
         exist_vpc = self.__get_cluster_resources(resources_list=vpcs_data, input_resource_id='VpcId')
         zombies = self.__get_zombie_resources(exist_vpc)
+        zombies = self._filter_zombies_by_vpc(zombies, vpcs_data, vpc_key='VpcId')
         delete_dict = {"ELB": self.zombie_cluster_load_balancer, "ELBV2": self.zombie_cluster_load_balancer_v2,
                        "VPCE": self.zombie_cluster_vpc_endpoint, "DHCP": self.zombie_cluster_dhcp_option,
                        "RT": self.zombie_cluster_route_table, "SG": self.zombie_cluster_security_group,
@@ -586,6 +633,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         subnets_data = self.ec2_operations.get_subnets()
         exist_subnet = self.__get_cluster_resources(resources_list=subnets_data, input_resource_id='SubnetId')
         zombies = self.__get_zombie_resources(exist_subnet)
+        zombies = self._filter_zombies_by_vpc(zombies, subnets_data, vpc_key='SubnetId')
         if not zombies and vpc_id:
             zombies = self.__get_zombies_by_vpc_id(vpc_id=vpc_id, resources=subnets_data, output_tag='SubnetId',
                                                    cluster_tag=cluster_tag_vpc)
@@ -621,6 +669,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         exist_route_table = self.__get_cluster_resources(resources_list=route_tables_data,
                                                          input_resource_id='RouteTableId')
         zombies = self.__get_zombie_resources(exist_route_table)
+        zombies = self._filter_zombies_by_vpc(zombies, route_tables_data, vpc_key='RouteTableId')
         if not zombies and vpc_id:
             zombies = self.__get_zombies_by_vpc_id(vpc_id=vpc_id, resources=route_tables_data,
                                                    output_tag='RouteTableId', cluster_tag=cluster_tag_vpc)
@@ -657,6 +706,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         exist_internet_gateway = self.__get_cluster_resources(resources_list=internet_gateways_data,
                                                               input_resource_id='InternetGatewayId')
         zombies = self.__get_zombie_resources(exist_internet_gateway)
+        zombies = self._filter_zombies_by_vpc(zombies, internet_gateways_data, vpc_key='InternetGatewayId')
         if not zombies and vpc_id:
             zombies = self.__get_zombies_by_vpc_id(vpc_id=vpc_id, resources=internet_gateways_data,
                                                    output_tag='InternetGatewayId', input_tag='Attachments',
@@ -703,6 +753,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         exist_dhcp_option = self.__get_cluster_resources(resources_list=dhcp_options_data,
                                                          input_resource_id='DhcpOptionsId')
         zombies = self.__get_zombie_resources(exist_dhcp_option)
+        zombies = self._filter_zombies_by_vpc(zombies, dhcp_options_data, vpc_key='DhcpOptionsId')
         resources = self._get_tags_of_zombie_resources(resources=dhcp_options_data, resource_id_name='DhcpOptionsId',
                                                        zombies=zombies, aws_service='ec2')
         cluster_left_out_days = {}
@@ -737,6 +788,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         exist_vpc_endpoint = self.__get_cluster_resources(resources_list=vpc_endpoints_data,
                                                           input_resource_id='VpcEndpointId')
         zombies = self.__get_zombie_resources(exist_vpc_endpoint)
+        zombies = self._filter_zombies_by_vpc(zombies, vpc_endpoints_data, vpc_key='VpcEndpointId')
         if not zombies and vpc_id:
             zombies = self.__get_zombies_by_vpc_id(vpc_id=vpc_id, resources=vpc_endpoints_data,
                                                    output_tag='VpcEndpointId', cluster_tag=cluster_tag_vpc)
@@ -752,7 +804,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
                     zombie_ids = self.__get_zombies_by_vpc_id(vpc_id=vpc_id, resources=vpc_endpoints_data,
                                                               output_tag='VpcEndpointId', cluster_tag=cluster_tag)
                 else:
-                    zombie_ids = [zombies]
+                    zombie_ids = [zombie]
                 cluster_left_out_days, delete_cluster_resource = self._check_zombie_cluster_deleted_days(
                     resources=resources, cluster_left_out_days=cluster_left_out_days, zombie=zombie,
                     cluster_tag=cluster_tag)
@@ -776,6 +828,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         exist_nat_gateway = self.__get_cluster_resources(resources_list=nat_gateways_data,
                                                          input_resource_id='NatGatewayId')
         zombies = self.__get_zombie_resources(exist_nat_gateway)
+        zombies = self._filter_zombies_by_vpc(zombies, nat_gateways_data, vpc_key='NatGatewayId')
         if not zombies and vpc_id:
             zombies = self.__get_zombies_by_vpc_id(vpc_id=vpc_id, resources=nat_gateways_data,
                                                    output_tag='NatGatewayId', cluster_tag=cluster_tag_vpc)
@@ -875,7 +928,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
                                 if self.cluster_tag == tag['Key']:
                                     exist_role_name_tag[role_name] = tag['Key']
                                     break
-        zombies = []
+        zombies = {}
         cluster_left_out_days = {}
         if exist_role_name_tag:
             zombies = self.__get_all_zombie_resources(exist_role_name_tag)

--- a/jenkins/clouds/aws/daily/policies/Jenkinsfile
+++ b/jenkins/clouds/aws/daily/policies/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
     environment {
         QUAY_CLOUD_GOVERNANCE_REPOSITORY = credentials('QUAY_CLOUD_GOVERNANCE_REPOSITORY')
-        POLICIES_IN_ACTION = '["instance_idle", "ec2_stop", "unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "zombie_cluster_resource", "delete_access_key"]'
+        POLICIES_IN_ACTION = '["instance_idle", "ec2_stop", "unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "delete_access_key"]'
         AWS_IAM_USER_SPREADSHEET_ID = credentials('cloud-governance-aws-iam-user-spreadsheet-id')
         GOOGLE_APPLICATION_CREDENTIALS = credentials('cloud-governance-google-application-credentials')
         LDAP_HOST_NAME = credentials('cloud-governance-ldap-host-name')

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_detection.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_detection.py
@@ -1,0 +1,482 @@
+import boto3
+from moto import mock_aws
+
+from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterResources
+from tests.unittest.configs import DEFAULT_AMI_ID
+
+REGION = 'us-east-2'
+CLUSTER_PREFIX = ['kubernetes.io/cluster', 'sigs.k8s.io/cluster-api-provider-aws/cluster']
+CLUSTER_NAME = 'unittest-test-cluster-abc123'
+K8S_TAG = f'kubernetes.io/cluster/{CLUSTER_NAME}'
+CAPA_TAG = f'sigs.k8s.io/cluster-api-provider-aws/cluster/{CLUSTER_NAME}'
+
+
+@mock_aws
+def test_f1_capa_sg_not_zombie_when_instance_has_k8s_tag():
+    """
+    Instance tagged with kubernetes.io/cluster/X, SG tagged with sigs.k8s.io/.../X.
+    Same cluster, different prefix — SG should NOT be detected as zombie.
+    """
+    ec2_client = boto3.client('ec2', region_name=REGION)
+    ec2_resource = boto3.resource('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    subnet = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock='10.0.1.0/24')
+
+    ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1,
+        SubnetId=subnet['Subnet']['SubnetId'],
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': K8S_TAG, 'Value': 'owned'}]}]
+    )
+    sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='test-capa-sg',
+        Description='CAPA SG with sigs.k8s.io tag',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': CAPA_TAG, 'Value': 'owned'}]}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert sg_id not in zombies
+
+
+@mock_aws
+def test_f1_different_cluster_names_is_zombie():
+    """
+    Instance tagged with cluster-A, SG tagged with cluster-B in a separate empty VPC.
+    SG should be zombie because cluster-B has no instances.
+    """
+    ec2_client = boto3.client('ec2', region_name=REGION)
+    ec2_resource = boto3.resource('ec2', region_name=REGION)
+
+    vpc_a = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    subnet_a = ec2_client.create_subnet(VpcId=vpc_a['Vpc']['VpcId'], CidrBlock='10.0.1.0/24')
+
+    vpc_b = ec2_client.create_vpc(CidrBlock='10.1.0.0/16')
+    vpc_b_id = vpc_b['Vpc']['VpcId']
+
+    ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1,
+        SubnetId=subnet_a['Subnet']['SubnetId'],
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': 'kubernetes.io/cluster/cluster-A', 'Value': 'owned'}]}]
+    )
+    sg = ec2_client.create_security_group(
+        VpcId=vpc_b_id, GroupName='test-diff-cluster-sg',
+        Description='SG from different cluster in empty VPC',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': 'sigs.k8s.io/cluster-api-provider-aws/cluster/cluster-B',
+                                     'Value': 'owned'}]}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert sg_id in zombies
+
+
+@mock_aws
+def test_f1_no_instances_capa_sg_is_zombie():
+    """No instances at all — SG with CAPA cluster tag should be detected as zombie."""
+    ec2_client = boto3.client('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    sg = ec2_client.create_security_group(
+        VpcId=vpc['Vpc']['VpcId'], GroupName='test-orphan-sg', Description='Orphaned SG',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': CAPA_TAG, 'Value': 'owned'}]}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert sg_id in zombies
+
+
+@mock_aws
+def test_f1_ipi_cluster_no_regression():
+    """IPI cluster: instance and SG both tagged with kubernetes.io/cluster/X — SG should NOT be zombie."""
+    ec2_client = boto3.client('ec2', region_name=REGION)
+    ec2_resource = boto3.resource('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    subnet = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock='10.0.1.0/24')
+
+    ipi_tag = [{'Key': K8S_TAG, 'Value': 'owned'}]
+    ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1,
+        SubnetId=subnet['Subnet']['SubnetId'],
+        TagSpecifications=[{'ResourceType': 'instance', 'Tags': ipi_tag}]
+    )
+    sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='test-ipi-sg', Description='IPI SG',
+        TagSpecifications=[{'ResourceType': 'security-group', 'Tags': ipi_tag}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert sg_id not in zombies
+
+
+@mock_aws
+def test_f1_instance_with_both_tags_sg_with_only_capa_tag():
+    """
+    Instance has both kubernetes.io and sigs.k8s.io tags; SG has only sigs.k8s.io tag.
+    Same cluster — SG should NOT be zombie.
+    """
+    ec2_client = boto3.client('ec2', region_name=REGION)
+    ec2_resource = boto3.resource('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    subnet = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock='10.0.1.0/24')
+
+    ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1,
+        SubnetId=subnet['Subnet']['SubnetId'],
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': K8S_TAG, 'Value': 'owned'},
+                                    {'Key': CAPA_TAG, 'Value': 'owned'}]}]
+    )
+    sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='test-capa-only-sg', Description='SG with CAPA tag only',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': CAPA_TAG, 'Value': 'owned'}]}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert sg_id not in zombies
+
+
+@mock_aws
+def test_f1_cross_prefix_subnet_not_zombie():
+    """Subnet tagged with CAPA prefix, instance with kubernetes.io prefix — same cluster, NOT zombie."""
+    ec2_client = boto3.client('ec2', region_name=REGION)
+    ec2_resource = boto3.resource('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    subnet = ec2_client.create_subnet(
+        VpcId=vpc_id, CidrBlock='10.0.1.0/24',
+        TagSpecifications=[{'ResourceType': 'subnet',
+                           'Tags': [{'Key': CAPA_TAG, 'Value': 'owned'}]}]
+    )
+    subnet_id = subnet['Subnet']['SubnetId']
+
+    ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1,
+        SubnetId=subnet_id,
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': K8S_TAG, 'Value': 'owned'}]}]
+    )
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_subnet()
+
+    assert subnet_id not in zombies
+
+
+@mock_aws
+def test_f1_mixed_ipi_and_capa_clusters_in_same_account():
+    """
+    Two clusters in same account — IPI (kubernetes.io tags) and CAPA (sigs.k8s.io on SGs).
+    Neither SG should be detected as zombie.
+    """
+    ec2_client = boto3.client('ec2', region_name=REGION)
+    ec2_resource = boto3.resource('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    subnet = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock='10.0.1.0/24')
+    subnet_id = subnet['Subnet']['SubnetId']
+
+    ipi_cluster = 'ipi-cluster-def456'
+    capa_cluster = 'capa-cluster-ghi789'
+
+    ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1, SubnetId=subnet_id,
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': f'kubernetes.io/cluster/{ipi_cluster}', 'Value': 'owned'}]}]
+    )
+    ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1, SubnetId=subnet_id,
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': f'kubernetes.io/cluster/{capa_cluster}', 'Value': 'owned'}]}]
+    )
+
+    ipi_sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='ipi-sg', Description='IPI SG',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': f'kubernetes.io/cluster/{ipi_cluster}', 'Value': 'owned'}]}]
+    )['GroupId']
+
+    capa_sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='capa-sg', Description='CAPA SG',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': f'sigs.k8s.io/cluster-api-provider-aws/cluster/{capa_cluster}',
+                                     'Value': 'owned'}]}]
+    )['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert ipi_sg not in zombies
+    assert capa_sg not in zombies
+
+
+@mock_aws
+def test_f2_sg_in_vpc_with_instances_not_zombie():
+    """SG in a VPC with running instances should NOT be zombie (VPC instance safety net)."""
+    ec2_client = boto3.client('ec2', region_name=REGION)
+    ec2_resource = boto3.resource('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    subnet = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock='10.0.1.0/24')
+
+    ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1,
+        SubnetId=subnet['Subnet']['SubnetId'],
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': 'kubernetes.io/cluster/other-cluster', 'Value': 'owned'}]}]
+    )
+    sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='test-vpc-check-sg', Description='SG in VPC with instances',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': 'kubernetes.io/cluster/dead-cluster-xyz', 'Value': 'owned'}]}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert sg_id not in zombies
+
+
+@mock_aws
+def test_f2_sg_in_empty_vpc_is_zombie():
+    """SG in a VPC with zero instances should be detected as zombie."""
+    ec2_client = boto3.client('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    sg = ec2_client.create_security_group(
+        VpcId=vpc['Vpc']['VpcId'], GroupName='test-empty-vpc-sg', Description='SG in empty VPC',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': K8S_TAG, 'Value': 'owned'}]}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert sg_id in zombies
+
+
+@mock_aws
+def test_f2_vpc_filter_applies_to_route_tables():
+    """Route table in VPC with running instances should NOT be zombie (VPC filter applies to all VPC-bound types)."""
+    ec2_client = boto3.client('ec2', region_name=REGION)
+    ec2_resource = boto3.resource('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    subnet = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock='10.0.1.0/24')
+
+    ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1,
+        SubnetId=subnet['Subnet']['SubnetId'],
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': 'kubernetes.io/cluster/alive-cluster', 'Value': 'owned'}]}]
+    )
+    rt = ec2_client.create_route_table(
+        VpcId=vpc_id,
+        TagSpecifications=[{'ResourceType': 'route-table',
+                           'Tags': [{'Key': 'kubernetes.io/cluster/dead-cluster', 'Value': 'owned'}]}]
+    )
+    rt_id = rt['RouteTable']['RouteTableId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_route_table()
+
+    assert rt_id not in zombies
+
+
+@mock_aws
+def test_f3_vpc_tag_no_substring_match():
+    """
+    VPC tagged with kubernetes.io/cluster/abc-test-cluster.
+    Searching for cluster tag kubernetes.io/cluster/abc should NOT match (no substring match).
+    """
+    ec2_client = boto3.client('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(
+        CidrBlock='10.0.0.0/16',
+        TagSpecifications=[{'ResourceType': 'vpc',
+                           'Tags': [{'Key': 'kubernetes.io/cluster/abc-test-cluster', 'Value': 'owned'}]}]
+    )
+    vpc_id = vpc['Vpc']['VpcId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    result = zcr._ZombieClusterResources__get_vpc_tags(
+        vpc_id=vpc_id, cluster_tag='kubernetes.io/cluster/abc'
+    )
+
+    assert result == ''
+
+
+@mock_aws
+def test_f11_resource_name_does_not_override_cluster_id():
+    """
+    SG has a cluster tag AND a Name tag whose value matches resource_name.
+    The cluster ID stored should be the cluster tag key, not 'Name'.
+    """
+    ec2_client = boto3.client('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+
+    sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='test-override-sg', Description='SG with Name tag',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': K8S_TAG, 'Value': 'owned'},
+                                    {'Key': 'Name', 'Value': 'my-special-sg'}]}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(
+        cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION,
+        resource_name='my-special-sg'
+    )
+    security_groups = zcr.ec2_operations.get_security_groups()
+    result = zcr._ZombieClusterResources__get_cluster_resources(
+        resources_list=security_groups, input_resource_id='GroupId'
+    )
+
+    if sg_id in result:
+        assert result[sg_id] == K8S_TAG
+
+
+@mock_aws
+def test_f13_vpc_endpoint_zombie_ids_are_strings():
+    """
+    VPC endpoint with no matching instances should be detected as zombie,
+    and all keys in the returned dict should be string IDs (not dicts).
+    """
+    ec2_client = boto3.client('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpce = ec2_client.create_vpc_endpoint(
+        VpcId=vpc['Vpc']['VpcId'],
+        ServiceName='com.amazonaws.us-east-2.s3',
+        TagSpecifications=[{'ResourceType': 'vpc-endpoint',
+                           'Tags': [{'Key': K8S_TAG, 'Value': 'owned'}]}]
+    )
+    vpce_id = vpce['VpcEndpoint']['VpcEndpointId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_vpc_endpoint()
+
+    assert vpce_id in zombies
+    for zombie_id in zombies:
+        assert isinstance(zombie_id, str)
+
+
+@mock_aws
+def test_stopped_instance_prevents_zombie_detection():
+    """Stopped (not terminated) instance should still protect its cluster SG from zombie detection."""
+    ec2_client = boto3.client('ec2', region_name=REGION)
+    ec2_resource = boto3.resource('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    subnet = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock='10.0.1.0/24')
+
+    instances = ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1,
+        SubnetId=subnet['Subnet']['SubnetId'],
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': K8S_TAG, 'Value': 'owned'}]}]
+    )
+    ec2_client.stop_instances(InstanceIds=[instances[0].instance_id])
+
+    sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='test-stopped-cluster-sg', Description='SG for stopped cluster',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': K8S_TAG, 'Value': 'owned'}]}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert sg_id not in zombies
+
+
+@mock_aws
+def test_reverse_cross_prefix_not_zombie():
+    """Instance has only sigs.k8s.io tag, SG has only kubernetes.io tag — same cluster, NOT zombie."""
+    ec2_client = boto3.client('ec2', region_name=REGION)
+    ec2_resource = boto3.resource('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    subnet = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock='10.0.1.0/24')
+
+    ec2_resource.create_instances(
+        ImageId=DEFAULT_AMI_ID, MinCount=1, MaxCount=1,
+        SubnetId=subnet['Subnet']['SubnetId'],
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': CAPA_TAG, 'Value': 'owned'}]}]
+    )
+    sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='test-reverse-capa-sg', Description='SG with k8s tag',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                           'Tags': [{'Key': K8S_TAG, 'Value': 'owned'}]}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert sg_id not in zombies
+
+
+@mock_aws
+def test_dead_cluster_resources_detected():
+    """Genuinely dead cluster with no instances — both SG and subnet should be detected as zombie."""
+    ec2_client = boto3.client('ec2', region_name=REGION)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    dead_tag = [{'Key': 'kubernetes.io/cluster/dead-cluster-xyz789', 'Value': 'owned'}]
+
+    sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='dead-cluster-sg', Description='Dead cluster SG',
+        TagSpecifications=[{'ResourceType': 'security-group', 'Tags': dead_tag}]
+    )
+    sg_id = sg['GroupId']
+
+    subnet = ec2_client.create_subnet(
+        VpcId=vpc_id, CidrBlock='10.0.1.0/24',
+        TagSpecifications=[{'ResourceType': 'subnet', 'Tags': dead_tag}]
+    )
+    subnet_id = subnet['Subnet']['SubnetId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    sg_zombies, _ = zcr.zombie_cluster_security_group()
+    subnet_zombies, _ = zcr.zombie_cluster_subnet()
+
+    assert sg_id in sg_zombies
+    assert subnet_id in subnet_zombies

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_detection.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_detection.py
@@ -364,8 +364,8 @@ def test_f11_resource_name_does_not_override_cluster_id():
         resources_list=security_groups, input_resource_id='GroupId'
     )
 
-    if sg_id in result:
-        assert result[sg_id] == K8S_TAG
+    assert sg_id in result
+    assert result[sg_id] == K8S_TAG
 
 
 @mock_aws

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_ec2_cluster_delete_resource.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_ec2_cluster_delete_resource.py
@@ -694,13 +694,14 @@ def test_f12_elastic_ip_includes_association_zombies():
         TagSpecifications=[{'ResourceType': 'network-interface',
                            'Tags': [{'Key': K8S_TAG_EIP, 'Value': 'owned'}]}]
     )
-    ec2_client.associate_address(
+    association_resp = ec2_client.associate_address(
         AllocationId=allocation_id,
         NetworkInterfaceId=eni['NetworkInterface']['NetworkInterfaceId']
     )
+    association_id = association_resp['AssociationId']
     ec2_client.create_tags(Resources=[allocation_id], Tags=[{'Key': K8S_TAG_EIP, 'Value': 'owned'}])
 
     zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=region_name)
     zombies, _ = zcr.zombie_cluster_elastic_ip()
 
-    assert len(zombies) > 0
+    assert association_id in zombies

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_ec2_cluster_delete_resource.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_ec2_cluster_delete_resource.py
@@ -5,7 +5,7 @@ from moto import mock_aws
 from cloud_governance.main.environment_variables import environment_variables
 from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterResources
 from cloud_governance.common.clouds.aws.ec2.ec2_operations import EC2Operations
-from tests.unittest.configs import DRY_RUN_YES, DRY_RUN_NO
+from tests.unittest.configs import DRY_RUN_YES, DRY_RUN_NO, DEFAULT_AMI_ID
 
 tags = [
     {'Key': 'kubernetes.io/cluster/unittest-test-cluster', 'Value': 'Owned'},
@@ -664,3 +664,43 @@ def test_delete_security_group_with_icmp_rule():
 
     zombie_cluster_resources.zombie_cluster_security_group()
     assert not EC2Operations(region_name).find_security_group(sg1)
+
+
+# ---------------------------------------------------------------------------
+# F12: Elastic IP dict merge fix
+# ---------------------------------------------------------------------------
+
+CLUSTER_PREFIX = ['kubernetes.io/cluster', 'sigs.k8s.io/cluster-api-provider-aws/cluster']
+K8S_TAG_EIP = 'kubernetes.io/cluster/unittest-test-cluster-abc123'
+
+
+@mock_aws
+def test_f12_elastic_ip_includes_association_zombies():
+    """
+    Elastic IP associated with an ENI that carries a cluster tag.
+    The EIP should appear in the returned zombies dict — association-based
+    entries must not be dropped by the dict merge.
+    """
+    ec2_client = boto3.client('ec2', region_name=region_name)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    subnet = ec2_client.create_subnet(VpcId=vpc['Vpc']['VpcId'], CidrBlock='10.0.1.0/24')
+
+    eip = ec2_client.allocate_address(Domain='vpc')
+    allocation_id = eip['AllocationId']
+
+    eni = ec2_client.create_network_interface(
+        SubnetId=subnet['Subnet']['SubnetId'],
+        TagSpecifications=[{'ResourceType': 'network-interface',
+                           'Tags': [{'Key': K8S_TAG_EIP, 'Value': 'owned'}]}]
+    )
+    ec2_client.associate_address(
+        AllocationId=allocation_id,
+        NetworkInterfaceId=eni['NetworkInterface']['NetworkInterfaceId']
+    )
+    ec2_client.create_tags(Resources=[allocation_id], Tags=[{'Key': K8S_TAG_EIP, 'Value': 'owned'}])
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=region_name)
+    zombies, _ = zcr.zombie_cluster_elastic_ip()
+
+    assert len(zombies) > 0

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_iam_cluster_delete_resource.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_iam_cluster_delete_resource.py
@@ -185,3 +185,60 @@ def test_not_delete_iam_cluster_user():
             find = True
             break
     assert find
+
+
+# ---------------------------------------------------------------------------
+# Role return type fix + cross-prefix IAM detection
+# ---------------------------------------------------------------------------
+
+CLUSTER_PREFIX_IAM = ['kubernetes.io/cluster', 'sigs.k8s.io/cluster-api-provider-aws/cluster']
+CLUSTER_NAME_IAM = 'unittest-test-cluster-abc123'
+K8S_TAG_IAM = f'kubernetes.io/cluster/{CLUSTER_NAME_IAM}'
+CAPA_TAG_IAM = f'sigs.k8s.io/cluster-api-provider-aws/cluster/{CLUSTER_NAME_IAM}'
+REGION_IAM = 'us-east-2'
+
+
+@mock_aws
+def test_zombie_cluster_role_returns_dict():
+    """zombie_cluster_role should return a dict (not list) as the first element of the tuple."""
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX_IAM, delete=False, region=REGION_IAM)
+    zombies, _ = zcr.zombie_cluster_role()
+    assert isinstance(zombies, dict)
+
+
+@mock_aws
+def test_iam_role_cross_prefix_not_zombie():
+    """
+    IAM role tagged with sigs.k8s.io prefix, EC2 instance with kubernetes.io prefix.
+    Same cluster name — role should NOT be detected as zombie.
+    """
+    ec2_client = boto3.client('ec2', region_name=REGION_IAM)
+    ec2_resource = boto3.resource('ec2', region_name=REGION_IAM)
+    iam_client = boto3.client('iam', region_name=REGION_IAM)
+
+    vpc = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')
+    subnet = ec2_client.create_subnet(VpcId=vpc['Vpc']['VpcId'], CidrBlock='10.0.1.0/24')
+
+    ec2_resource.create_instances(
+        ImageId='ami-03cf127a', MinCount=1, MaxCount=1,
+        SubnetId=subnet['Subnet']['SubnetId'],
+        TagSpecifications=[{'ResourceType': 'instance',
+                           'Tags': [{'Key': K8S_TAG_IAM, 'Value': 'owned'}]}]
+    )
+
+    assume_role_doc = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"},
+                       "Action": "sts:AssumeRole"}]
+    })
+    role_name = f'{CLUSTER_NAME_IAM}-worker-role'
+    iam_client.create_role(
+        RoleName=role_name,
+        AssumeRolePolicyDocument=assume_role_doc,
+        Tags=[{'Key': CAPA_TAG_IAM, 'Value': 'owned'}]
+    )
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX_IAM, delete=False, region=REGION_IAM)
+    zombies, _ = zcr.zombie_cluster_role()
+
+    assert role_name not in zombies


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
The policy incorrectly detected active OpenShift cluster security groups as zombie resources when instances and security groups carried different cluster tag prefixes (CCM vs CAPA).

Root cause: zombie detection compared full tag key strings, so `kubernetes.io/cluster/X` and `sigs.k8s.io/cluster-api-provider-aws/cluster/X` were treated as different clusters, causing CAPA-provisioned security groups to be falsely classified as orphaned.

A secondary bug in Utils.is_cluster_resource caused non-deterministic visibility of CAPA resources due to variable shadowing in the inner for-loop.

Fixes:
- F1: Extract cluster name from tag key before comparison so resources tagged with different cluster prefixes resolve to the same cluster. Applied to __get_zombie_resources and __get_all_zombie_resources.
- F2: Add VPC instance check as a tag-agnostic safety net. Resources in a VPC with running instances are excluded from zombie detection. Applied to all VPC-bound resource types via _filter_zombies_by_vpc.
- F3: Fix __get_vpc_tags to use prefix-aware name matching instead of substring match, preventing cross-cluster false positives.
- F11: Remove else clause in __get_cluster_resources that allowed resource_name to overwrite the cluster ID with an unrelated tag key.
- F12: Fix elastic IP zombie detection — merge both association and allocation zombies and use the correct resource_id_name (AssociationId).
- F13: Fix VPC endpoint loop variable (zombie_ids = [zombie] not [zombies]).
- is_cluster_resource: Fix variable shadowing where the for-loop variable shadowed the parameter, making CAPA resource detection non-deterministic based on AWS API tag ordering.

Deployment Notes:

  Enabling dry_run=yes (safe immediately after merge)

  dry_run=yes can be enabled as soon as this PR is merged. In this mode the policy detects zombie resources and logs them but does not write tags or delete anything.

  Recommended validation period: Run dry_run=yes for at least 7 days per account and verify:
  1. No active cluster resources appear in the zombie output (check for known live clusters by name)
  2. Genuine orphaned cluster resources are detected
  3. No errors in policy execution logs

  Enabling dry_run=no (requires additional fixes first)

  Do not enable dry_run=no until the follow-up PR covering deletion safety is merged. That PR addresses:
  - Security group ingress rules being revoked before deletion with no rollback (root cause of the original incident)
  - Counter logic bugs that can cause premature deletion

## For security reasons, all pull requests need to be approved first before running any automated CI

_Assisted-by : Claude_