### PR TITLE
Add Orion container image Dockerfile

### DIFF
--- a/Docker/orion/Dockerfile
+++ b/Docker/orion/Dockerfile
@@ -1,0 +1,45 @@
+# Based on cloud-bulldozer/orion's own Dockerfile, with fixes found while validating
+# this integration (see CLGOVNR-91):
+#   - python-311 instead of python-314: orion pins scikit-learn==1.5.0, which has no
+#     prebuilt wheel for cp314 and fails to build from source in this base image.
+#   - no forced --no-binary build of cryptography: the source build fails via cargo/maturin;
+#     the prebuilt wheel works fine for our use.
+#   - single stage instead of multi-stage: the final stage's COPY --from=builder breaks on
+#     Fedora's /opt/app-root/lib64 -> lib symlink, since the builder's manual site-packages
+#     extraction step turns it into a real directory instead of preserving the symlink.
+FROM quay.io/fedora/python-311:latest
+
+USER 0
+
+RUN dnf install -y \
+    git \
+    gcc \
+    make \
+    rust \
+    cargo \
+    openssl-devel \
+    python3-devel \
+    pkg-config \
+    && dnf clean all
+
+WORKDIR /build
+
+# Pinned to a specific commit for reproducible builds.
+ARG ORION_COMMIT=b0acf1948e017164a45ca0af309b69d05ed4735a
+RUN git clone https://github.com/cloud-bulldozer/orion.git . && \
+    git checkout "${ORION_COMMIT}"
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir setuptools && \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir .
+
+ENV PYTHONUNBUFFERED="1"
+
+# orion writes its output (CSV/report files) to the current working directory;
+# /tmp is writable by any UID, unlike /build which is root-owned from the build above.
+WORKDIR /tmp
+
+USER 1001
+
+ENTRYPOINT ["orion"]

--- a/Docker/orion/Dockerfile
+++ b/Docker/orion/Dockerfile
@@ -1,5 +1,5 @@
 # Based on cloud-bulldozer/orion's own Dockerfile, with fixes found while validating
-# this integration (see CLGOVNR-91):
+# this integration:
 #   - python-311 instead of python-314: orion pins scikit-learn==1.5.0, which has no
 #     prebuilt wheel for cp314 and fails to build from source in this base image.
 #   - no forced --no-binary build of cryptography: the source build fails via cargo/maturin;

--- a/Docker/orion/Dockerfile
+++ b/Docker/orion/Dockerfile
@@ -7,7 +7,7 @@
 #   - single stage instead of multi-stage: the final stage's COPY --from=builder breaks on
 #     Fedora's /opt/app-root/lib64 -> lib symlink, since the builder's manual site-packages
 #     extraction step turns it into a real directory instead of preserving the symlink.
-FROM quay.io/fedora/python-311:latest
+FROM quay.io/fedora/python-311@sha256:aabd8125b244b6eb71baa91d3e0b1921a0205a8e9d47961ebcabb7a5a529436e
 
 USER 0
 
@@ -29,8 +29,8 @@ ARG ORION_COMMIT=b0acf1948e017164a45ca0af309b69d05ed4735a
 RUN git clone https://github.com/cloud-bulldozer/orion.git . && \
     git checkout "${ORION_COMMIT}"
 
-RUN pip install --upgrade pip && \
-    pip install --no-cache-dir setuptools && \
+RUN pip install --upgrade pip==26.1.2 && \
+    pip install --no-cache-dir setuptools==65.5.1 && \
     pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir .
 


### PR DESCRIPTION
## Summary
Adds a Dockerfile for building the Orion (cloud-bulldozer/orion) container image, with a few fixes needed for a clean build:
- Use the Python 3.11 base image instead of 3.14 (no prebuilt `scikit-learn` wheel available for cp314 at the pinned version)
- Drop the forced source build of `cryptography` (fails to build via cargo/maturin in this environment)
- Single-stage build instead of multi-stage (the multi-stage `COPY` step conflicts with the base image's `/opt/app-root/lib64 -> lib` symlink)

## Test plan
- Built the image successfully
- Verified the container runs as non-root with a writable working directory
- Ran the image against a test OpenSearch index and confirmed Orion correctly detects a regression

_Assisted-by : Claude_