### PR TITLE
Add Orion metrics rollup job

### DIFF
--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -106,7 +106,7 @@ class EnvironmentVariables:
         es_index = 'cloud-governance-policy-es-index'
         self._environment_variables_dict['cost_policies'] = ['cost_explorer', 'cost_over_usage', 'cost_billing_reports',
                                                              'cost_explorer_payer_billings', 'spot_savings_analysis',
-                                                             'yearly_savings_report']
+                                                             'yearly_savings_report', 'orion_metrics_rollup']
         self._environment_variables_dict['ibm_policies'] = ['tag_baremetal', 'tag_vm', 'ibm_cost_report',
                                                             'ibm_cost_over_usage']
         self._environment_variables_dict['azure_policies'] = ['tag_azure_resource_group']
@@ -152,6 +152,9 @@ class EnvironmentVariables:
         self._environment_variables_dict['yearly_savings_start_date'] = EnvironmentVariables.get_env('yearly_savings_start_date', '')
         self._environment_variables_dict['yearly_savings_end_date'] = EnvironmentVariables.get_env('yearly_savings_end_date', '')
         self._environment_variables_dict['yearly_savings_es_index'] = EnvironmentVariables.get_env('yearly_savings_es_index', 'cloud-governance-yearly-saving')
+        self._environment_variables_dict['orion_rollup_start_date'] = EnvironmentVariables.get_env('orion_rollup_start_date', '')
+        self._environment_variables_dict['orion_rollup_end_date'] = EnvironmentVariables.get_env('orion_rollup_end_date', '')
+        self._environment_variables_dict['orion_metrics_es_index'] = EnvironmentVariables.get_env('orion_metrics_es_index', 'cloud-governance-orion-metrics-index')
         # AZURE Credentials
         self._environment_variables_dict['AZURE_ACCOUNT_ID'] = EnvironmentVariables.get_env('AZURE_ACCOUNT_ID', '')
         self._environment_variables_dict['AZURE_CLIENT_ID'] = EnvironmentVariables.get_env('AZURE_CLIENT_ID', '')

--- a/cloud_governance/policy/aws/orion_metrics_rollup.py
+++ b/cloud_governance/policy/aws/orion_metrics_rollup.py
@@ -208,6 +208,9 @@ class OrionMetricsRollup:
         if not end_date:
             end_date = self.__custom_end_date
 
+        if bool(start_date) != bool(end_date):
+            logger.warning(f'Ignoring partial date range (start_date={start_date}, end_date={end_date}); both must be set to backfill. Falling back to daily mode.')
+
         if start_date and end_date:
             logger.info(f'Backfilling Orion metrics rollup from {start_date} to {end_date}')
             monthly_ranges = self.__split_date_range_by_month(start_date, end_date)

--- a/cloud_governance/policy/aws/orion_metrics_rollup.py
+++ b/cloud_governance/policy/aws/orion_metrics_rollup.py
@@ -19,6 +19,8 @@ class OrionMetricsRollup:
     # policy in cost_policies (this one included), that var defaults to the
     # cost-billing index, not the policy index this rollup needs to read from.
     SOURCE_ES_INDEX = 'cloud-governance-policy-es-index'
+    # Per-policy resource counts are restricted to these. monitored_policies_savings
+    # is NOT restricted to these - see __build_query for why.
     TRACKED_POLICIES = ['zombie_cluster_resource', 's3_inactive', 'ec2_stop', 'unused_access_key', 'delete_access_key']
 
     def __init__(self):
@@ -68,6 +70,13 @@ class OrionMetricsRollup:
     def __build_query(self, start_date: str, end_date: str):
         """
         Build the account/day/policy aggregation query for a single date-range chunk.
+
+        Deliberately does not filter by policy at the top level: none of the
+        tracked policies populate TotalYearlySavings (confirmed against
+        production data - they're risk/hygiene policies, not
+        idle-resource-elimination policies), so monitored_policies_savings is
+        summed across all policies for the account/day, while by_policy below
+        restricts the per-policy counts to just the tracked set via 'include'.
         @param start_date: Start date string (YYYY-MM-DD)
         @param end_date: End date string (YYYY-MM-DD)
         @return: ES query dict
@@ -77,8 +86,7 @@ class OrionMetricsRollup:
             "query": {
                 "bool": {
                     "filter": [
-                        {"range": {"timestamp": {"gte": start_date, "lte": end_date, "format": "yyyy-MM-dd"}}},
-                        {"terms": {"policy.keyword": self.TRACKED_POLICIES}}
+                        {"range": {"timestamp": {"gte": start_date, "lte": end_date, "format": "yyyy-MM-dd"}}}
                     ]
                 }
             },
@@ -90,7 +98,7 @@ class OrionMetricsRollup:
                             "date_histogram": {"field": "timestamp", "calendar_interval": "day", "format": "yyyy-MM-dd"},
                             "aggs": {
                                 "by_policy": {
-                                    "terms": {"field": "policy.keyword", "size": len(self.TRACKED_POLICIES)}
+                                    "terms": {"field": "policy.keyword", "include": self.TRACKED_POLICIES, "size": len(self.TRACKED_POLICIES)}
                                 },
                                 "total_savings": {
                                     "sum": {"field": "TotalYearlySavings", "missing": 0}

--- a/cloud_governance/policy/aws/orion_metrics_rollup.py
+++ b/cloud_governance/policy/aws/orion_metrics_rollup.py
@@ -1,0 +1,219 @@
+from datetime import datetime, timezone, date, timedelta
+import time
+
+from cloud_governance.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
+from cloud_governance.common.logger.init_logger import logger
+from cloud_governance.common.logger.logger_time_stamp import logger_time_stamp
+from cloud_governance.main.environment_variables import environment_variables
+
+
+class OrionMetricsRollup:
+    """
+    Rolls up per-resource policy execution data from the policy ES index into
+    one document per account per day, for a fixed set of tracked policies, so
+    Orion (change-point regression detection) can watch each metric as its own
+    time series.
+    """
+
+    # Read from explicitly, rather than the shared 'es_index' env var: for any
+    # policy in cost_policies (this one included), that var defaults to the
+    # cost-billing index, not the policy index this rollup needs to read from.
+    SOURCE_ES_INDEX = 'cloud-governance-policy-es-index'
+    TRACKED_POLICIES = ['zombie_cluster_resource', 's3_inactive', 'ec2_stop', 'unused_access_key', 'delete_access_key']
+
+    def __init__(self):
+        self.__environment_variables_dict = environment_variables.environment_variables_dict
+        self.__es_host = self.__environment_variables_dict.get('es_host', '')
+        self.__es_port = self.__environment_variables_dict.get('es_port', '')
+        self.__elastic_operations = ElasticSearchOperations(es_host=self.__es_host, es_port=self.__es_port) if self.__es_host else None
+        self.__destination_es_index = self.__environment_variables_dict.get('orion_metrics_es_index', 'cloud-governance-orion-metrics-index')
+        self.__custom_start_date = self.__environment_variables_dict.get('orion_rollup_start_date', '')
+        self.__custom_end_date = self.__environment_variables_dict.get('orion_rollup_end_date', '')
+
+    def __split_date_range_by_month(self, start_date: str, end_date: str):
+        """
+        Split a date range into monthly (start, end) string chunks, to avoid
+        querying ES with an unbounded date range.
+        @param start_date: Start date string (YYYY-MM-DD)
+        @param end_date: End date string (YYYY-MM-DD)
+        @return: list of (month_start, month_end) string tuples
+        """
+        if not start_date or not end_date:
+            raise ValueError(f"Both start_date and end_date must be provided. Got: start_date={start_date}, end_date={end_date}")
+
+        start = datetime.strptime(start_date, "%Y-%m-%d").date()
+        end = datetime.strptime(end_date, "%Y-%m-%d").date()
+
+        if start > end:
+            raise ValueError(f"start_date ({start_date}) must be <= end_date ({end_date})")
+
+        monthly_ranges = []
+        current_start = start
+
+        while current_start <= end:
+            if current_start.month == 12:
+                current_end = date(current_start.year + 1, 1, 1) - timedelta(days=1)
+            else:
+                current_end = date(current_start.year, current_start.month + 1, 1) - timedelta(days=1)
+            if current_end > end:
+                current_end = end
+            monthly_ranges.append((current_start.strftime("%Y-%m-%d"), current_end.strftime("%Y-%m-%d")))
+            if current_end.month == 12:
+                current_start = date(current_end.year + 1, 1, 1)
+            else:
+                current_start = date(current_end.year, current_end.month + 1, 1)
+
+        return monthly_ranges
+
+    def __build_query(self, start_date: str, end_date: str):
+        """
+        Build the account/day/policy aggregation query for a single date-range chunk.
+        @param start_date: Start date string (YYYY-MM-DD)
+        @param end_date: End date string (YYYY-MM-DD)
+        @return: ES query dict
+        """
+        return {
+            "size": 0,
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"range": {"timestamp": {"gte": start_date, "lte": end_date, "format": "yyyy-MM-dd"}}},
+                        {"terms": {"policy.keyword": self.TRACKED_POLICIES}}
+                    ]
+                }
+            },
+            "aggs": {
+                "by_account": {
+                    "terms": {"field": "account.keyword", "size": 1000},
+                    "aggs": {
+                        "by_day": {
+                            "date_histogram": {"field": "timestamp", "calendar_interval": "day", "format": "yyyy-MM-dd"},
+                            "aggs": {
+                                "by_policy": {
+                                    "terms": {"field": "policy.keyword", "size": len(self.TRACKED_POLICIES)}
+                                },
+                                "total_savings": {
+                                    "sum": {"field": "TotalYearlySavings", "missing": 0}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    def __parse_response(self, response: dict):
+        """
+        Walk the account -> day aggregation buckets and build one rollup
+        document per account per day.
+        @param response: the 'aggregations' dict returned by post_query(result_agg=True)
+        @return: list of rollup documents
+        """
+        documents = []
+        if not response or 'by_account' not in response:
+            return documents
+
+        for account_bucket in response.get('by_account', {}).get('buckets', []):
+            account = account_bucket.get('key')
+            for day_bucket in account_bucket.get('by_day', {}).get('buckets', []):
+                day = day_bucket.get('key_as_string', '')[:10]
+                if not day:
+                    continue
+                document = {f'{policy}_count': 0 for policy in self.TRACKED_POLICIES}
+                for policy_bucket in day_bucket.get('by_policy', {}).get('buckets', []):
+                    policy_name = policy_bucket.get('key')
+                    if policy_name in self.TRACKED_POLICIES:
+                        document[f'{policy_name}_count'] = policy_bucket.get('doc_count', 0)
+                savings = day_bucket.get('total_savings', {}).get('value') or 0
+                document['monitored_policies_savings'] = round(savings)
+                document['uuid'] = f'{account}-{day}'
+                document['timestamp'] = f'{day}T00:00:00Z'
+                document['account'] = account
+                documents.append(document)
+        return documents
+
+    def __upsert_document(self, document: dict):
+        """
+        Create or update a single rollup document, keyed by its deterministic uuid.
+        @param document: rollup document, must include a 'uuid' key
+        """
+        doc_id = document['uuid']
+        try:
+            if self.__elastic_operations.verify_elastic_index_doc_id(index=self.__destination_es_index, doc_id=doc_id):
+                self.__elastic_operations.update_elasticsearch_index(
+                    index=self.__destination_es_index,
+                    id=doc_id,
+                    metadata=document
+                )
+            else:
+                self.__elastic_operations.upload_to_elasticsearch(
+                    index=self.__destination_es_index,
+                    data=document,
+                    id=doc_id
+                )
+        except Exception as err:
+            logger.warning(f"Update check failed for {doc_id}, trying create: {err}")
+            self.__elastic_operations.upload_to_elasticsearch(
+                index=self.__destination_es_index,
+                data=document,
+                id=doc_id
+            )
+
+    def __process_date_range(self, start_date: str, end_date: str):
+        """
+        Query and upsert rollup documents for a single date-range chunk.
+        @param start_date: Start date string (YYYY-MM-DD)
+        @param end_date: End date string (YYYY-MM-DD)
+        @return: number of documents written
+        """
+        query = self.__build_query(start_date=start_date, end_date=end_date)
+        response = self.__elastic_operations.post_query(
+            query=query,
+            es_index=self.SOURCE_ES_INDEX,
+            result_agg=True
+        )
+        documents = self.__parse_response(response)
+        for document in documents:
+            self.__upsert_document(document)
+        return len(documents)
+
+    @logger_time_stamp
+    def run(self, start_date: str = None, end_date: str = None):
+        """
+        Roll up per-resource policy data into one document per account per day.
+
+        If start_date/end_date are given (directly, or via the
+        orion_rollup_start_date/orion_rollup_end_date env vars), backfills that
+        range, chunked by month. Otherwise, rolls up just the current UTC date
+        - the daily incremental mode used in production, run right after that
+        day's policy jobs complete.
+        @param start_date: Optional start date string (YYYY-MM-DD)
+        @param end_date: Optional end date string (YYYY-MM-DD)
+        @return: dict summarizing what was written
+        """
+        if not self.__elastic_operations:
+            logger.warning('ES not configured, skipping Orion metrics rollup')
+            return {'status': 'no_upload', 'message': 'ES not configured'}
+
+        if not start_date:
+            start_date = self.__custom_start_date
+        if not end_date:
+            end_date = self.__custom_end_date
+
+        if start_date and end_date:
+            logger.info(f'Backfilling Orion metrics rollup from {start_date} to {end_date}')
+            monthly_ranges = self.__split_date_range_by_month(start_date, end_date)
+            total_documents = 0
+            for i, (month_start, month_end) in enumerate(monthly_ranges, 1):
+                logger.info(f'Processing month {i}/{len(monthly_ranges)}: {month_start} to {month_end}')
+                total_documents += self.__process_date_range(month_start, month_end)
+                if i < len(monthly_ranges):
+                    time.sleep(0.5)
+            logger.info(f'Orion metrics rollup backfill complete: {total_documents} documents written')
+            return {'status': 'success', 'documents_written': total_documents, 'start_date': start_date, 'end_date': end_date}
+
+        today = datetime.now(timezone.utc).date().strftime('%Y-%m-%d')
+        logger.info(f'Running daily Orion metrics rollup for {today}')
+        total_documents = self.__process_date_range(today, today)
+        logger.info(f'Orion metrics rollup complete for {today}: {total_documents} documents written')
+        return {'status': 'success', 'documents_written': total_documents, 'date': today}

--- a/tests/unittest/cloud_governance/policy/aws/test_orion_metrics_rollup.py
+++ b/tests/unittest/cloud_governance/policy/aws/test_orion_metrics_rollup.py
@@ -183,6 +183,18 @@ class TestOrionMetricsRollup:
         assert 'date' in result
         assert self.mock_es_instance.post_query.call_count == 1
 
+    def test_run_with_only_start_date_falls_back_to_daily_mode_with_warning(self):
+        """A partial date range (only one of start/end set) must not silently backfill - and must warn"""
+        self.mock_es_instance.post_query.return_value = {'by_account': {'buckets': []}}
+
+        with patch('cloud_governance.policy.aws.orion_metrics_rollup.logger') as mock_logger:
+            result = self.rollup.run(start_date='2026-01-01')
+
+        assert 'date' in result
+        assert 'start_date' not in result
+        assert self.mock_es_instance.post_query.call_count == 1
+        assert any('partial date range' in call.args[0].lower() for call in mock_logger.warning.call_args_list)
+
     def test_run_backfill_mode_chunks_by_month(self):
         """With an explicit date range spanning two months, run() should query once per month"""
         self.mock_es_instance.post_query.return_value = {'by_account': {'buckets': []}}

--- a/tests/unittest/cloud_governance/policy/aws/test_orion_metrics_rollup.py
+++ b/tests/unittest/cloud_governance/policy/aws/test_orion_metrics_rollup.py
@@ -192,9 +192,17 @@ class TestOrionMetricsRollup:
         assert result['status'] == 'success'
         assert self.mock_es_instance.post_query.call_count == 2
 
-    def test_build_query_filters_to_tracked_policies_only(self):
-        """The source query must scope to the tracked policies, not every policy in the index"""
+    def test_build_query_restricts_counts_but_not_savings_to_tracked_policies(self):
+        """
+        Counts must be scoped to the tracked policies via the by_policy 'include',
+        but the top-level query must NOT filter by policy, since none of the
+        tracked policies populate TotalYearlySavings - monitored_policies_savings
+        needs to see every policy's docs to be a meaningful, non-zero signal.
+        """
         query = self.rollup._OrionMetricsRollup__build_query('2026-07-01', '2026-07-31')
 
-        policy_filter = query['query']['bool']['filter'][1]['terms']['policy.keyword']
-        assert set(policy_filter) == set(OrionMetricsRollup.TRACKED_POLICIES)
+        filter_clauses = query['query']['bool']['filter']
+        assert not any('terms' in clause and clause['terms'].get('policy.keyword') for clause in filter_clauses)
+
+        by_policy_agg = query['aggs']['by_account']['aggs']['by_day']['aggs']['by_policy']['terms']
+        assert set(by_policy_agg['include']) == set(OrionMetricsRollup.TRACKED_POLICIES)

--- a/tests/unittest/cloud_governance/policy/aws/test_orion_metrics_rollup.py
+++ b/tests/unittest/cloud_governance/policy/aws/test_orion_metrics_rollup.py
@@ -1,0 +1,200 @@
+from unittest.mock import patch, MagicMock
+
+from cloud_governance.policy.aws.orion_metrics_rollup import OrionMetricsRollup
+from tests.unittest.configs import ES_INDEX
+
+
+class TestOrionMetricsRollup:
+    """Test suite for OrionMetricsRollup class"""
+
+    def setup_method(self):
+        """Setup test fixtures"""
+        with patch('cloud_governance.policy.aws.orion_metrics_rollup.environment_variables') as mock_env_vars, \
+             patch('cloud_governance.policy.aws.orion_metrics_rollup.ElasticSearchOperations') as mock_es_ops:
+            mock_env_vars.environment_variables_dict = {
+                'es_host': 'localhost',
+                'es_port': '9200',
+                'es_index': ES_INDEX,
+                'account': 'TEST-ACCOUNT',
+                'orion_metrics_es_index': 'cloud-governance-orion-metrics-index'
+            }
+            mock_es_instance = MagicMock()
+            mock_es_ops.return_value = mock_es_instance
+            self.rollup = OrionMetricsRollup()
+            self.mock_es_instance = mock_es_instance
+
+    def test_split_date_range_by_month(self):
+        """Test __split_date_range_by_month method"""
+        ranges = self.rollup._OrionMetricsRollup__split_date_range_by_month('2026-01-01', '2026-01-31')
+        assert len(ranges) == 1
+        assert ranges[0] == ('2026-01-01', '2026-01-31')
+
+        ranges = self.rollup._OrionMetricsRollup__split_date_range_by_month('2026-01-15', '2026-02-20')
+        assert len(ranges) == 2
+        assert ranges[0] == ('2026-01-15', '2026-01-31')
+        assert ranges[1] == ('2026-02-01', '2026-02-20')
+
+        try:
+            self.rollup._OrionMetricsRollup__split_date_range_by_month('2026-01-15', '2026-01-10')
+            assert False, "Should raise ValueError"
+        except ValueError as e:
+            assert "must be <=" in str(e)
+
+        try:
+            self.rollup._OrionMetricsRollup__split_date_range_by_month('', '2026-01-10')
+            assert False, "Should raise ValueError"
+        except ValueError as e:
+            assert "must be provided" in str(e)
+
+    def test_parse_response_fills_all_tracked_policies(self):
+        """A day with only some policies present should still get a 0 count for the others"""
+        response = {
+            'by_account': {
+                'buckets': [
+                    {
+                        'key': 'my-account',
+                        'by_day': {
+                            'buckets': [
+                                {
+                                    'key_as_string': '2026-07-04T00:00:00.000Z',
+                                    'by_policy': {
+                                        'buckets': [
+                                            {'key': 'zombie_cluster_resource', 'doc_count': 25},
+                                            {'key': 'ec2_stop', 'doc_count': 3}
+                                        ]
+                                    },
+                                    'total_savings': {'value': 1234.6}
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+
+        documents = self.rollup._OrionMetricsRollup__parse_response(response)
+
+        assert len(documents) == 1
+        doc = documents[0]
+        assert doc['uuid'] == 'my-account-2026-07-04'
+        assert doc['timestamp'] == '2026-07-04T00:00:00Z'
+        assert doc['account'] == 'my-account'
+        assert doc['zombie_cluster_resource_count'] == 25
+        assert doc['ec2_stop_count'] == 3
+        # untouched tracked policies default to 0, not missing
+        assert doc['s3_inactive_count'] == 0
+        assert doc['unused_access_key_count'] == 0
+        assert doc['delete_access_key_count'] == 0
+        # rounded to a whole number, not a float
+        assert doc['monitored_policies_savings'] == 1235
+        assert isinstance(doc['monitored_policies_savings'], int)
+
+    def test_parse_response_empty_day_defaults_to_zero(self):
+        """A day bucket with no matching policy docs should produce an all-zero document, not be skipped"""
+        response = {
+            'by_account': {
+                'buckets': [
+                    {
+                        'key': 'quiet-account',
+                        'by_day': {
+                            'buckets': [
+                                {
+                                    'key_as_string': '2026-07-05T00:00:00.000Z',
+                                    'by_policy': {'buckets': []},
+                                    'total_savings': {'value': 0}
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+
+        documents = self.rollup._OrionMetricsRollup__parse_response(response)
+
+        assert len(documents) == 1
+        doc = documents[0]
+        for policy in OrionMetricsRollup.TRACKED_POLICIES:
+            assert doc[f'{policy}_count'] == 0
+        assert doc['monitored_policies_savings'] == 0
+
+    def test_parse_response_handles_missing_aggregations(self):
+        """An unexpected/empty response should produce no documents, not raise"""
+        assert self.rollup._OrionMetricsRollup__parse_response({}) == []
+        assert self.rollup._OrionMetricsRollup__parse_response(None) == []
+
+    def test_upsert_document_updates_when_doc_exists(self):
+        """If the doc id already exists, update it instead of creating a new one"""
+        self.mock_es_instance.verify_elastic_index_doc_id.return_value = True
+        document = {'uuid': 'my-account-2026-07-04', 'zombie_cluster_resource_count': 5}
+
+        self.rollup._OrionMetricsRollup__upsert_document(document)
+
+        self.mock_es_instance.update_elasticsearch_index.assert_called_once_with(
+            index='cloud-governance-orion-metrics-index',
+            id='my-account-2026-07-04',
+            metadata=document
+        )
+        self.mock_es_instance.upload_to_elasticsearch.assert_not_called()
+
+    def test_upsert_document_creates_when_doc_missing(self):
+        """If the doc id doesn't exist yet, create it"""
+        self.mock_es_instance.verify_elastic_index_doc_id.return_value = False
+        document = {'uuid': 'my-account-2026-07-05', 'zombie_cluster_resource_count': 0}
+
+        self.rollup._OrionMetricsRollup__upsert_document(document)
+
+        self.mock_es_instance.upload_to_elasticsearch.assert_called_once_with(
+            index='cloud-governance-orion-metrics-index',
+            data=document,
+            id='my-account-2026-07-05'
+        )
+        self.mock_es_instance.update_elasticsearch_index.assert_not_called()
+
+    def test_upsert_document_falls_back_to_create_on_update_error(self):
+        """If checking/updating an existing doc errors out, fall back to create rather than losing the data"""
+        self.mock_es_instance.verify_elastic_index_doc_id.side_effect = Exception('connection reset')
+        document = {'uuid': 'my-account-2026-07-06', 'zombie_cluster_resource_count': 1}
+
+        self.rollup._OrionMetricsRollup__upsert_document(document)
+
+        self.mock_es_instance.upload_to_elasticsearch.assert_called_once_with(
+            index='cloud-governance-orion-metrics-index',
+            data=document,
+            id='my-account-2026-07-06'
+        )
+
+    def test_run_without_es_configured(self):
+        """run() should no-op cleanly when ES isn't configured, not raise"""
+        with patch('cloud_governance.policy.aws.orion_metrics_rollup.environment_variables') as mock_env_vars:
+            mock_env_vars.environment_variables_dict = {'es_host': '', 'es_port': ''}
+            rollup = OrionMetricsRollup()
+            result = rollup.run()
+            assert result == {'status': 'no_upload', 'message': 'ES not configured'}
+
+    def test_run_daily_mode_defaults_to_today(self):
+        """With no start/end date given, run() should roll up a single day (today), not backfill"""
+        self.mock_es_instance.post_query.return_value = {'by_account': {'buckets': []}}
+
+        result = self.rollup.run()
+
+        assert result['status'] == 'success'
+        assert result['documents_written'] == 0
+        assert 'date' in result
+        assert self.mock_es_instance.post_query.call_count == 1
+
+    def test_run_backfill_mode_chunks_by_month(self):
+        """With an explicit date range spanning two months, run() should query once per month"""
+        self.mock_es_instance.post_query.return_value = {'by_account': {'buckets': []}}
+
+        result = self.rollup.run(start_date='2026-01-15', end_date='2026-02-10')
+
+        assert result['status'] == 'success'
+        assert self.mock_es_instance.post_query.call_count == 2
+
+    def test_build_query_filters_to_tracked_policies_only(self):
+        """The source query must scope to the tracked policies, not every policy in the index"""
+        query = self.rollup._OrionMetricsRollup__build_query('2026-07-01', '2026-07-31')
+
+        policy_filter = query['query']['bool']['filter'][1]['terms']['policy.keyword']
+        assert set(policy_filter) == set(OrionMetricsRollup.TRACKED_POLICIES)


### PR DESCRIPTION
## Summary
Adds a job that rolls up per-resource policy execution data from the policy index into one document per account per day, for use with Orion (change-point regression detection):
- Counts for 5 tracked policies: zombie_cluster_resource, s3_inactive, ec2_stop, unused_access_key, delete_access_key
- An aggregate `monitored_policies_savings` figure across all policies for that account/day (the 5 tracked policies don't populate a savings value themselves - confirmed against production data)
- Wired in via the existing cost_policies dispatch mechanism (same pattern as yearly_savings_report), no changes to the main dispatcher needed
- Supports both a one-time backfill (chunked by month) and the default daily incremental mode

## Test plan
- Unit tests covering aggregation parsing, zero-fill behavior, and upsert create/update/fallback logic
- Ran live against a real OpenSearch cluster: backfilled 90 days of real production data, confirmed the resulting index has correct per-account-per-day documents
- Fed the real rollup output into Orion and confirmed it correctly detects real change-points in production data (not synthetic test data)