### PR TITLE
Add Hypershift support and unify CLUSTER_PREFIX across all policies

### DIFF
--- a/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/monitor_cro_instances.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/monitor_cro_instances.py
@@ -30,6 +30,13 @@ class MonitorCROInstances:
             tags = resource.get('Tags')
             ticket_id = self.__ec2_operations.get_tag_value_from_tags(tag_name=self.__cro_resource_tag_name, tags=tags)
             cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags, tag_name='kubernetes.io/cluster/')
+            if not cluster_key:
+                for prefix in self.__environment_variables_dict.get('CLUSTER_PREFIX', []):
+                    if prefix == 'kubernetes.io/cluster':
+                        continue
+                    cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags, tag_name=f'{prefix}/')
+                    if cluster_key:
+                        break
             hcp_key, hcp_name = check_name_and_get_key_from_tags(tags=tags, tag_name='api.openshift.com/name')
             if hcp_name:
                 cluster_key = hcp_name

--- a/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/monitor_cro_instances.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/monitor_cro_instances.py
@@ -31,7 +31,7 @@ class MonitorCROInstances:
             ticket_id = self.__ec2_operations.get_tag_value_from_tags(tag_name=self.__cro_resource_tag_name, tags=tags)
             cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags, tag_name='kubernetes.io/cluster/')
             if not cluster_key:
-                for prefix in self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"]):
+                for prefix in self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"]):
                     if prefix == 'kubernetes.io/cluster':
                         continue
                     cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags, tag_name=f'{prefix}/')

--- a/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/monitor_cro_instances.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/aws/ec2/monitor_cro_instances.py
@@ -31,7 +31,7 @@ class MonitorCROInstances:
             ticket_id = self.__ec2_operations.get_tag_value_from_tags(tag_name=self.__cro_resource_tag_name, tags=tags)
             cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags, tag_name='kubernetes.io/cluster/')
             if not cluster_key:
-                for prefix in self.__environment_variables_dict.get('CLUSTER_PREFIX', []):
+                for prefix in self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"]):
                     if prefix == 'kubernetes.io/cluster':
                         continue
                     cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags, tag_name=f'{prefix}/')

--- a/cloud_governance/cloud_resource_orchestration/clouds/azure/resource_groups/monitor_cro_resources.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/azure/resource_groups/monitor_cro_resources.py
@@ -4,6 +4,7 @@ from cloud_governance.cloud_resource_orchestration.clouds.azure.resource_groups.
     AbstractResource
 from cloud_governance.cloud_resource_orchestration.utils.common_operations import check_name_and_get_key_from_tags
 from cloud_governance.cloud_resource_orchestration.utils.constant_variables import DURATION, TICKET_ID
+from cloud_governance.main.environment_variables import environment_variables
 
 
 class MonitorCROResources(AbstractResource):
@@ -51,6 +52,13 @@ class MonitorCROResources(AbstractResource):
                 ticket_id = self._compute_client.check_tag_name(tags=tags, tag_name=TICKET_ID)
                 cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags,
                                                                               tag_name='kubernetes.io/cluster/')
+                if not cluster_key:
+                    for prefix in environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', []):
+                        if prefix == 'kubernetes.io/cluster':
+                            continue
+                        cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags, tag_name=f'{prefix}/')
+                        if cluster_key:
+                            break
                 hcp_key, hcp_name = check_name_and_get_key_from_tags(tags=tags, tag_name='api.openshift.com/name')
                 if hcp_name:
                     cluster_key = hcp_name

--- a/cloud_governance/cloud_resource_orchestration/clouds/azure/resource_groups/monitor_cro_resources.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/azure/resource_groups/monitor_cro_resources.py
@@ -53,7 +53,7 @@ class MonitorCROResources(AbstractResource):
                 cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags,
                                                                               tag_name='kubernetes.io/cluster/')
                 if not cluster_key:
-                    for prefix in environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"]):
+                    for prefix in environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"]):
                         if prefix == 'kubernetes.io/cluster':
                             continue
                         cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags, tag_name=f'{prefix}/')

--- a/cloud_governance/cloud_resource_orchestration/clouds/azure/resource_groups/monitor_cro_resources.py
+++ b/cloud_governance/cloud_resource_orchestration/clouds/azure/resource_groups/monitor_cro_resources.py
@@ -53,7 +53,7 @@ class MonitorCROResources(AbstractResource):
                 cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags,
                                                                               tag_name='kubernetes.io/cluster/')
                 if not cluster_key:
-                    for prefix in environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', []):
+                    for prefix in environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"]):
                         if prefix == 'kubernetes.io/cluster':
                             continue
                         cluster_key, cluster_value = check_name_and_get_key_from_tags(tags=tags, tag_name=f'{prefix}/')

--- a/cloud_governance/common/clouds/aws/ec2/ec2_operations.py
+++ b/cloud_governance/common/clouds/aws/ec2/ec2_operations.py
@@ -27,7 +27,7 @@ class EC2Operations:
         self.ec2_client = get_boto3_client('ec2', region_name=region)
         self.get_full_list = Utils().get_details_resource_list
         self.utils = Utils(region=region)
-        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
 
     @logger_time_stamp
     @typeguard.typechecked

--- a/cloud_governance/common/clouds/aws/ec2/ec2_operations.py
+++ b/cloud_governance/common/clouds/aws/ec2/ec2_operations.py
@@ -27,7 +27,7 @@ class EC2Operations:
         self.ec2_client = get_boto3_client('ec2', region_name=region)
         self.get_full_list = Utils().get_details_resource_list
         self.utils = Utils(region=region)
-        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX')
+        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', [])
 
     @logger_time_stamp
     @typeguard.typechecked

--- a/cloud_governance/common/clouds/aws/ec2/ec2_operations.py
+++ b/cloud_governance/common/clouds/aws/ec2/ec2_operations.py
@@ -27,7 +27,7 @@ class EC2Operations:
         self.ec2_client = get_boto3_client('ec2', region_name=region)
         self.get_full_list = Utils().get_details_resource_list
         self.utils = Utils(region=region)
-        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', [])
+        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
 
     @logger_time_stamp
     @typeguard.typechecked

--- a/cloud_governance/common/clouds/aws/utils/utils.py
+++ b/cloud_governance/common/clouds/aws/utils/utils.py
@@ -119,13 +119,13 @@ class Utils:
         :return:
         """
         for prefix in cluster_prefix:
-            prefix = prefix.strip()
+            prefix = prefix.strip().rstrip('/')
             if tag:
-                if tag.get('Key').startswith(prefix):
+                if tag.get('Key').startswith(f'{prefix}/'):
                     return True, tag.get('Key')
             else:
                 if tags:
                     for t in tags:
-                        if t.get('Key').startswith(prefix):
+                        if t.get('Key').startswith(f'{prefix}/'):
                             return True, t.get('Key')
         return False, None

--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -141,9 +141,12 @@ class EnvironmentVariables:
                 'CLUSTER_PREFIX',
                 '["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"]'
             ))
-            _normalized = [p.strip().rstrip('/') for p in _parsed if isinstance(p, str)]
-            if _normalized and all(_normalized):
-                self._environment_variables_dict['CLUSTER_PREFIX'] = _normalized
+            if isinstance(_parsed, list):
+                _normalized = [p.strip().rstrip('/') for p in _parsed if isinstance(p, str)]
+                if _normalized and all(_normalized):
+                    self._environment_variables_dict['CLUSTER_PREFIX'] = _normalized
+                else:
+                    self._environment_variables_dict['CLUSTER_PREFIX'] = _cluster_prefix_default
             else:
                 self._environment_variables_dict['CLUSTER_PREFIX'] = _cluster_prefix_default
         except json.JSONDecodeError:

--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -134,12 +134,13 @@ class EnvironmentVariables:
         try:
             self._environment_variables_dict['CLUSTER_PREFIX'] = json.loads(EnvironmentVariables.get_env(
                 'CLUSTER_PREFIX',
-                '["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"]'
+                '["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"]'
             ))
         except json.JSONDecodeError as err:
             self._environment_variables_dict['CLUSTER_PREFIX'] = [
                 "kubernetes.io/cluster",
-                "sigs.k8s.io/cluster-api-provider-aws/cluster"
+                "sigs.k8s.io/cluster-api-provider-aws/cluster",
+                "hypershift.openshift.io/cluster",
             ]
         # AWS Cost Explorer tags
         self._environment_variables_dict['cost_metric'] = EnvironmentVariables.get_env('cost_metric', 'UnblendedCost')

--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -141,8 +141,9 @@ class EnvironmentVariables:
                 'CLUSTER_PREFIX',
                 '["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"]'
             ))
-            if isinstance(_parsed, list) and _parsed and all(isinstance(p, str) and p for p in _parsed):
-                self._environment_variables_dict['CLUSTER_PREFIX'] = [p.rstrip('/') for p in _parsed]
+            _normalized = [p.strip().rstrip('/') for p in _parsed if isinstance(p, str)]
+            if _normalized and all(_normalized):
+                self._environment_variables_dict['CLUSTER_PREFIX'] = _normalized
             else:
                 self._environment_variables_dict['CLUSTER_PREFIX'] = _cluster_prefix_default
         except json.JSONDecodeError:

--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -131,17 +131,22 @@ class EnvironmentVariables:
                                                                                                 '{}')
         self._environment_variables_dict['DAYS_TO_DELETE_RESOURCE'] = int(
             EnvironmentVariables.get_env('DAYS_TO_DELETE_RESOURCE', '7'))
+        _cluster_prefix_default = [
+            "kubernetes.io/cluster",
+            "sigs.k8s.io/cluster-api-provider-aws/cluster",
+            "hypershift.openshift.io/cluster",
+        ]
         try:
-            self._environment_variables_dict['CLUSTER_PREFIX'] = json.loads(EnvironmentVariables.get_env(
+            _parsed = json.loads(EnvironmentVariables.get_env(
                 'CLUSTER_PREFIX',
                 '["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"]'
             ))
-        except json.JSONDecodeError as err:
-            self._environment_variables_dict['CLUSTER_PREFIX'] = [
-                "kubernetes.io/cluster",
-                "sigs.k8s.io/cluster-api-provider-aws/cluster",
-                "hypershift.openshift.io/cluster",
-            ]
+            if isinstance(_parsed, list) and _parsed and all(isinstance(p, str) and p for p in _parsed):
+                self._environment_variables_dict['CLUSTER_PREFIX'] = _parsed
+            else:
+                self._environment_variables_dict['CLUSTER_PREFIX'] = _cluster_prefix_default
+        except json.JSONDecodeError:
+            self._environment_variables_dict['CLUSTER_PREFIX'] = _cluster_prefix_default
         # AWS Cost Explorer tags
         self._environment_variables_dict['cost_metric'] = EnvironmentVariables.get_env('cost_metric', 'UnblendedCost')
         self._environment_variables_dict['start_date'] = EnvironmentVariables.get_env('start_date', '')

--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -142,7 +142,7 @@ class EnvironmentVariables:
                 '["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"]'
             ))
             if isinstance(_parsed, list) and _parsed and all(isinstance(p, str) and p for p in _parsed):
-                self._environment_variables_dict['CLUSTER_PREFIX'] = _parsed
+                self._environment_variables_dict['CLUSTER_PREFIX'] = [p.rstrip('/') for p in _parsed]
             else:
                 self._environment_variables_dict['CLUSTER_PREFIX'] = _cluster_prefix_default
         except json.JSONDecodeError:

--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -134,12 +134,11 @@ class EnvironmentVariables:
         _cluster_prefix_default = [
             "kubernetes.io/cluster",
             "sigs.k8s.io/cluster-api-provider-aws/cluster",
-            "hypershift.openshift.io/cluster",
         ]
         try:
             _parsed = json.loads(EnvironmentVariables.get_env(
                 'CLUSTER_PREFIX',
-                '["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"]'
+                '["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"]'
             ))
             if isinstance(_parsed, list):
                 _normalized = [p.strip().rstrip('/') for p in _parsed if isinstance(p, str)]

--- a/cloud_governance/policy/aws/zombie_cluster_resource.py
+++ b/cloud_governance/policy/aws/zombie_cluster_resource.py
@@ -84,6 +84,13 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
 
         return result_instance
 
+    @staticmethod
+    def _is_hypershift_managed(tags: list) -> bool:
+        for tag in (tags or []):
+            if tag.get('Key') == 'Policy' and tag.get('Value', '').lower() == 'hypershift-managed':
+                return True
+        return False
+
     def __get_cluster_resources(self, resources_list: list, input_resource_id: str, tags: str = 'Tags'):
         """
         This method returns all cluster resources keys that start with cluster prefix
@@ -99,6 +106,8 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
             else:
                 continue
             tags_list = resource.get(tags, [])
+            if self._is_hypershift_managed(tags_list):
+                continue
             if tags:
                 ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                            tags=tags_list)
@@ -343,6 +352,8 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         """
         ids = {}
         for resource in resources:
+            if self._is_hypershift_managed(resource.get(tags) or []):
+                continue
             if input_tag:
                 for attachment in resource.get(input_tag):
                     if attachment.get('VpcId') == vpc_id:
@@ -519,6 +530,8 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
             for item in tags['TagDescriptions']:
                 tags = item.get('Tags')
                 if tags:
+                    if self._is_hypershift_managed(tags):
+                        continue
                     ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                                tags=tags)
                     if ok:
@@ -562,6 +575,8 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
             for item in tags['TagDescriptions']:
                 tags = item.get('Tags', [])
                 if tags:
+                    if self._is_hypershift_managed(tags):
+                        continue
                     ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                                tags=tags)
                     if ok:
@@ -891,6 +906,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         """
         exist_network_acl = {}
         network_acls_data = self.ec2_operations.get_nacls()
+        network_acls_data = [n for n in network_acls_data if not self._is_hypershift_managed(n.get('Tags', []))]
         for resource in network_acls_data:
             exist_network_acl[resource['NetworkAclId']] = resource['VpcId']
         zombie_resources = {}
@@ -951,6 +967,8 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
                 data = role_data['Role']
                 tags = data.get('Tags', [])
                 if tags:
+                    if self._is_hypershift_managed(tags):
+                        continue
                     ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                                tags=tags)
                     if ok:
@@ -996,6 +1014,8 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
             data = user_data['User']
             tags = data.get('Tags', [])
             if tags:
+                if self._is_hypershift_managed(tags):
+                    continue
                 ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                            tags=tags)
                 if ok:
@@ -1042,6 +1062,8 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
                 except Exception as e:  # continue when no bucket tags
                     continue
                 tags = tags.get('TagSet', [])
+                if self._is_hypershift_managed(tags):
+                    continue
                 ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                            tags=tags)
                 if ok:
@@ -1070,5 +1092,5 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
 
         return zombies, cluster_left_out_days
 
-# zombie_cluster_resources = ZombieClusterResources(cluster_prefix=["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"], delete=False, region='us-east-2')
+# zombie_cluster_resources = ZombieClusterResources(cluster_prefix=["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"], delete=False, region='us-east-2')
 # print(zombie_cluster_resources.zombie_cluster_subnet())

--- a/cloud_governance/policy/aws/zombie_cluster_resource.py
+++ b/cloud_governance/policy/aws/zombie_cluster_resource.py
@@ -1070,5 +1070,5 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
 
         return zombies, cluster_left_out_days
 
-# zombie_cluster_resources = ZombieClusterResources(cluster_prefix=["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"], delete=False, region='us-east-2')
+# zombie_cluster_resources = ZombieClusterResources(cluster_prefix=["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"], delete=False, region='us-east-2')
 # print(zombie_cluster_resources.zombie_cluster_subnet())

--- a/cloud_governance/policy/aws/zombie_cluster_resource.py
+++ b/cloud_governance/policy/aws/zombie_cluster_resource.py
@@ -84,13 +84,6 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
 
         return result_instance
 
-    @staticmethod
-    def _is_hypershift_managed(tags: list) -> bool:
-        for tag in (tags or []):
-            if tag.get('Key') == 'Policy' and tag.get('Value', '').lower() == 'hypershift-managed':
-                return True
-        return False
-
     def __get_cluster_resources(self, resources_list: list, input_resource_id: str, tags: str = 'Tags'):
         """
         This method returns all cluster resources keys that start with cluster prefix
@@ -106,8 +99,6 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
             else:
                 continue
             tags_list = resource.get(tags, [])
-            if self._is_hypershift_managed(tags_list):
-                continue
             if tags:
                 ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                            tags=tags_list)
@@ -352,8 +343,6 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         """
         ids = {}
         for resource in resources:
-            if self._is_hypershift_managed(resource.get(tags) or []):
-                continue
             if input_tag:
                 for attachment in resource.get(input_tag):
                     if attachment.get('VpcId') == vpc_id:
@@ -530,8 +519,6 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
             for item in tags['TagDescriptions']:
                 tags = item.get('Tags')
                 if tags:
-                    if self._is_hypershift_managed(tags):
-                        continue
                     ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                                tags=tags)
                     if ok:
@@ -575,8 +562,6 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
             for item in tags['TagDescriptions']:
                 tags = item.get('Tags', [])
                 if tags:
-                    if self._is_hypershift_managed(tags):
-                        continue
                     ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                                tags=tags)
                     if ok:
@@ -906,7 +891,6 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         """
         exist_network_acl = {}
         network_acls_data = self.ec2_operations.get_nacls()
-        network_acls_data = [n for n in network_acls_data if not self._is_hypershift_managed(n.get('Tags', []))]
         for resource in network_acls_data:
             exist_network_acl[resource['NetworkAclId']] = resource['VpcId']
         zombie_resources = {}
@@ -967,8 +951,6 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
                 data = role_data['Role']
                 tags = data.get('Tags', [])
                 if tags:
-                    if self._is_hypershift_managed(tags):
-                        continue
                     ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                                tags=tags)
                     if ok:
@@ -1014,8 +996,6 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
             data = user_data['User']
             tags = data.get('Tags', [])
             if tags:
-                if self._is_hypershift_managed(tags):
-                    continue
                 ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                            tags=tags)
                 if ok:
@@ -1062,8 +1042,6 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
                 except Exception as e:  # continue when no bucket tags
                     continue
                 tags = tags.get('TagSet', [])
-                if self._is_hypershift_managed(tags):
-                    continue
                 ok, cluster_id = Utils.is_cluster_resource(cluster_prefix=self.cluster_prefix,
                                                            tags=tags)
                 if ok:

--- a/cloud_governance/policy/aws/zombie_cluster_resource.py
+++ b/cloud_governance/policy/aws/zombie_cluster_resource.py
@@ -168,7 +168,7 @@ class ZombieClusterResources(ZombieClusterCommonMethods):
         if not tag_key:
             return ''
         for prefix in self.cluster_prefix:
-            if tag_key.startswith(prefix):
+            if tag_key.startswith(f'{prefix}/'):
                 name = tag_key[len(prefix):].lstrip('/')
                 return name
         return tag_key

--- a/cloud_governance/policy/helpers/aws/aws_policy_operations.py
+++ b/cloud_governance/policy/helpers/aws/aws_policy_operations.py
@@ -260,7 +260,7 @@ class AWSPolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         active_instances = self._ec2_operations.get_ec2_instance_list()
-        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         cluster_ids = []
         for instance in active_instances:
             for tag in instance.get('Tags', []):
@@ -275,7 +275,7 @@ class AWSPolicyOperations(AbstractPolicyOperations):
         :return:
         """
         cluster_ids = []
-        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         active_regions = self._ec2_operations.get_active_regions()
         for region in active_regions:
             active_instances = self._ec2_operations.get_ec2_instance_list(
@@ -293,7 +293,7 @@ class AWSPolicyOperations(AbstractPolicyOperations):
         :return:
         :rtype:
         """
-        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         if tags:
             for tag in tags:
                 if any(tag.get('Key', '').startswith(p) for p in cluster_prefixes):

--- a/cloud_governance/policy/helpers/aws/aws_policy_operations.py
+++ b/cloud_governance/policy/helpers/aws/aws_policy_operations.py
@@ -260,7 +260,7 @@ class AWSPolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         active_instances = self._ec2_operations.get_ec2_instance_list()
-        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         cluster_ids = []
         for instance in active_instances:
             for tag in instance.get('Tags', []):
@@ -275,7 +275,7 @@ class AWSPolicyOperations(AbstractPolicyOperations):
         :return:
         """
         cluster_ids = []
-        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         active_regions = self._ec2_operations.get_active_regions()
         for region in active_regions:
             active_instances = self._ec2_operations.get_ec2_instance_list(
@@ -293,7 +293,7 @@ class AWSPolicyOperations(AbstractPolicyOperations):
         :return:
         :rtype:
         """
-        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         if tags:
             for tag in tags:
                 if any(tag.get('Key', '').startswith(p) for p in cluster_prefixes):

--- a/cloud_governance/policy/helpers/aws/aws_policy_operations.py
+++ b/cloud_governance/policy/helpers/aws/aws_policy_operations.py
@@ -260,10 +260,11 @@ class AWSPolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         active_instances = self._ec2_operations.get_ec2_instance_list()
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
         cluster_ids = []
         for instance in active_instances:
             for tag in instance.get('Tags', []):
-                if tag.get('Key', '').startswith('kubernetes.io/cluster'):
+                if any(tag.get('Key', '').startswith(p) for p in cluster_prefixes):
                     cluster_ids.append(tag.get('Key'))
                     break
         return cluster_ids
@@ -274,13 +275,14 @@ class AWSPolicyOperations(AbstractPolicyOperations):
         :return:
         """
         cluster_ids = []
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
         active_regions = self._ec2_operations.get_active_regions()
         for region in active_regions:
             active_instances = self._ec2_operations.get_ec2_instance_list(
                 ec2_client=get_boto3_client('ec2', region_name=region))
             for instance in active_instances:
                 for tag in instance.get('Tags', []):
-                    if tag.get('Key', '').startswith('kubernetes.io/cluster'):
+                    if any(tag.get('Key', '').startswith(p) for p in cluster_prefixes):
                         cluster_ids.append(tag.get('Key'))
                         break
         return cluster_ids
@@ -291,9 +293,10 @@ class AWSPolicyOperations(AbstractPolicyOperations):
         :return:
         :rtype:
         """
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
         if tags:
             for tag in tags:
-                if tag.get('Key').startswith('kubernetes.io/cluster'):
+                if any(tag.get('Key', '').startswith(p) for p in cluster_prefixes):
                     return tag.get('Key')
         return ''
 

--- a/cloud_governance/policy/helpers/azure/azure_policy_operations.py
+++ b/cloud_governance/policy/helpers/azure/azure_policy_operations.py
@@ -124,7 +124,7 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         active_instances = self._get_all_instances()
-        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         cluster_ids = []
         for vm in active_instances:
             tags = vm.tags if vm.tags else {}
@@ -140,7 +140,7 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :return:
         :rtype:
         """
-        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         if tags:
             for key, value in tags.items():
                 if any(key.startswith(p) for p in cluster_prefixes):

--- a/cloud_governance/policy/helpers/azure/azure_policy_operations.py
+++ b/cloud_governance/policy/helpers/azure/azure_policy_operations.py
@@ -124,11 +124,12 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         active_instances = self._get_all_instances()
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
         cluster_ids = []
         for vm in active_instances:
             tags = vm.tags if vm.tags else {}
             for key, value in tags.items():
-                if key.startswith('kubernetes.io/cluster'):
+                if any(key.startswith(p) for p in cluster_prefixes):
                     cluster_ids.append(key)
                     break
         return cluster_ids
@@ -139,9 +140,10 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :return:
         :rtype:
         """
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
         if tags:
             for key, value in tags.items():
-                if key.startswith('kubernetes.io/cluster'):
+                if any(key.startswith(p) for p in cluster_prefixes):
                     return key
         return ''
 

--- a/cloud_governance/policy/helpers/azure/azure_policy_operations.py
+++ b/cloud_governance/policy/helpers/azure/azure_policy_operations.py
@@ -124,7 +124,7 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :rtype:
         """
         active_instances = self._get_all_instances()
-        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         cluster_ids = []
         for vm in active_instances:
             tags = vm.tags if vm.tags else {}
@@ -140,7 +140,7 @@ class AzurePolicyOperations(AbstractPolicyOperations):
         :return:
         :rtype:
         """
-        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
+        cluster_prefixes = self._environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         if tags:
             for key, value in tags.items():
                 if any(key.startswith(p) for p in cluster_prefixes):

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/remove_cluster_tags.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/remove_cluster_tags.py
@@ -84,7 +84,7 @@ class RemoveClusterTags(TagClusterOperations):
                 if item.get('Tags'):
                     for tag in item.get('Tags'):
                         key = tag.get('Key')
-                        if any(prefix in key for prefix in self.cluster_prefix):
+                        if any(key.startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                             if self.cluster_name:
                                 if any(f'{prefix}/{self.cluster_name}' == key for prefix in self.cluster_prefix):
                                     if key in cluster_dict:
@@ -150,7 +150,7 @@ class RemoveClusterTags(TagClusterOperations):
         for resource in resource_list:
             if resource.get(tags):
                 for tag in resource.get(tags):
-                    if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                    if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                         if self.cluster_name:
                             if any(f'{prefix}/{self.cluster_name}' == tag.get('Key') for prefix in self.cluster_prefix):
                                 if tag.get('Key') in cluster_resources:
@@ -255,7 +255,7 @@ class RemoveClusterTags(TagClusterOperations):
             for item in tags['TagDescriptions']:
                 if item.get('Tags'):
                     for tag in item['Tags']:
-                        if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                        if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                             if self.cluster_name:
                                 if any(f'{prefix}/{self.cluster_name}' == tag.get('Key') for prefix in self.cluster_prefix):
                                     if tag.get('Key') in cluster_resources:
@@ -288,7 +288,7 @@ class RemoveClusterTags(TagClusterOperations):
             for item in tags['TagDescriptions']:
                 if item.get('Tags'):
                     for tag in item['Tags']:
-                        if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                        if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                             if self.cluster_name:
                                 if any(f'{prefix}/{self.cluster_name}' == tag.get('Key') for prefix in self.cluster_prefix):
                                     if tag.get('Key') in cluster_resources:

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/remove_cluster_tags.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/remove_cluster_tags.py
@@ -12,11 +12,18 @@ class RemoveClusterTags(TagClusterOperations):
     This class removes the tags of cluster resources
     """
 
-    def __init__(self, input_tags: dict, cluster_name: str = None, cluster_prefix: str = None,
+    def __init__(self, input_tags: dict, cluster_name: str = None, cluster_prefix: list = None,
                  region: str = 'us-east-2', cluster_only: bool = False):
         super().__init__(cluster_name=cluster_name, cluster_prefix=cluster_prefix, input_tags=input_tags, region=region, dry_run='no', cluster_only=cluster_only)
         self.__get_details_resource_list = Utils().get_details_resource_list
         self.non_cluster_update = RemoveNonClusterTags(region=region, dry_run='no', input_tags=input_tags)
+
+    def _resolve_full_name(self, cluster_name: str, instance_tags: dict) -> str:
+        for prefix in self.cluster_prefix:
+            candidate = f'{prefix}/{cluster_name}'
+            if candidate in instance_tags:
+                return candidate
+        return f'{self.cluster_prefix[0]}/{cluster_name}' if self.cluster_prefix else cluster_name
 
     def get_tags(self, tags: list):
         """
@@ -77,9 +84,9 @@ class RemoveClusterTags(TagClusterOperations):
                 if item.get('Tags'):
                     for tag in item.get('Tags'):
                         key = tag.get('Key')
-                        if self.cluster_prefix in key:
+                        if any(prefix in key for prefix in self.cluster_prefix):
                             if self.cluster_name:
-                                if f'{self.cluster_prefix}{self.cluster_name}' == key:
+                                if any(f'{prefix}/{self.cluster_name}' == key for prefix in self.cluster_prefix):
                                     if key in cluster_dict:
                                         cluster_dict[key].append(item.get('InstanceId'))
                                     else:
@@ -143,9 +150,9 @@ class RemoveClusterTags(TagClusterOperations):
         for resource in resource_list:
             if resource.get(tags):
                 for tag in resource.get(tags):
-                    if self.cluster_prefix in tag.get('Key'):
+                    if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
                         if self.cluster_name:
-                            if f'{self.cluster_prefix}{self.cluster_name}' == tag.get('Key'):
+                            if any(f'{prefix}/{self.cluster_name}' == tag.get('Key') for prefix in self.cluster_prefix):
                                 if tag.get('Key') in cluster_resources:
                                     cluster_resources[tag.get('Key')].append(resource.get(resource_id))
                                 else:
@@ -248,9 +255,9 @@ class RemoveClusterTags(TagClusterOperations):
             for item in tags['TagDescriptions']:
                 if item.get('Tags'):
                     for tag in item['Tags']:
-                        if self.cluster_prefix in tag.get('Key'):
+                        if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
                             if self.cluster_name:
-                                if f'{self.cluster_prefix}{self.cluster_name}' == tag.get('Key'):
+                                if any(f'{prefix}/{self.cluster_name}' == tag.get('Key') for prefix in self.cluster_prefix):
                                     if tag.get('Key') in cluster_resources:
                                         cluster_resources[tag.get('Key')].append(resource.get('LoadBalancerName'))
                                     else:
@@ -281,9 +288,9 @@ class RemoveClusterTags(TagClusterOperations):
             for item in tags['TagDescriptions']:
                 if item.get('Tags'):
                     for tag in item['Tags']:
-                        if self.cluster_prefix in tag.get('Key'):
+                        if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
                             if self.cluster_name:
-                                if f'{self.cluster_prefix}{self.cluster_name}' == tag.get('Key'):
+                                if any(f'{prefix}/{self.cluster_name}' == tag.get('Key') for prefix in self.cluster_prefix):
                                     if tag.get('Key') in cluster_resources:
                                         cluster_resources[tag.get('Key')].append(resource_id)
                                     else:
@@ -443,15 +450,15 @@ class RemoveClusterTags(TagClusterOperations):
             for role_name in role_name_list:
                 if self.cluster_name:
                     if self.cluster_name in role_name:
-                        full_name = f'{self.cluster_prefix}{self.cluster_name}'
-                        keys = self.tag_keys(list(instance_tags.get(full_name)))
+                        full_name = self._resolve_full_name(self.cluster_name, instance_tags)
+                        keys = self.tag_keys(list(instance_tags.get(full_name, [])))
                         self.iam_client.untag_role(RoleName=role_name, TagKeys=keys)
-                        tags = list(instance_tags.get(full_name))
+                        tags = list(instance_tags.get(full_name, []))
                 else:
-                    full_name = f'{self.cluster_prefix}{cluster_name}'
-                    keys = self.tag_keys(list(instance_tags.get(full_name)))
+                    full_name = self._resolve_full_name(cluster_name, instance_tags)
+                    keys = self.tag_keys(list(instance_tags.get(full_name, [])))
                     self.iam_client.untag_role(RoleName=role_name, TagKeys=keys)
-                    tags = list(instance_tags.get(full_name))
+                    tags = list(instance_tags.get(full_name, []))
             logger.info(f'Role Name :: {role_name_list} {tags}')
             cluster_ids.extend(role_name_list)
         return cluster_ids
@@ -474,17 +481,17 @@ class RemoveClusterTags(TagClusterOperations):
                 if cluster_name in user_name:
                     if self.cluster_name:
                         if self.cluster_name in user_name:
-                            full_name = f'{self.cluster_prefix}{self.cluster_name}'
-                            keys = self.tag_keys(instance_tags.get(full_name))
+                            full_name = self._resolve_full_name(self.cluster_name, instance_tags)
+                            keys = self.tag_keys(instance_tags.get(full_name, []))
                             self.iam_client.untag_user(UserName=user_name, TagKeys=keys)
                             usernames.append(user_name)
-                            tags = list(instance_tags.get(full_name))
+                            tags = list(instance_tags.get(full_name, []))
                     else:
-                        full_name = f'{self.cluster_prefix}{cluster_name}'
-                        keys = self.tag_keys(list(instance_tags.get(full_name)))
+                        full_name = self._resolve_full_name(cluster_name, instance_tags)
+                        keys = self.tag_keys(list(instance_tags.get(full_name, [])))
                         self.iam_client.untag_user(UserName=user_name, TagKeys=keys)
                         usernames.append(user_name)
-                        tags = list(instance_tags.get(full_name))
+                        tags = list(instance_tags.get(full_name, []))
             logger.info(f'IAM Users : {usernames}, {tags}')
             user_ids.extend(usernames)
         return user_ids
@@ -521,8 +528,8 @@ class RemoveClusterTags(TagClusterOperations):
                     bucket_tags = self.s3_client.get_bucket_tagging(Bucket=bucket.get('Name'))
                     if bucket_tags:
                         bucket_tags = bucket_tags['TagSet']
-                        full_name = f'{self.cluster_prefix}{cluster_name}'
-                        added_tags = instance_tags.get(full_name)
+                        full_name = self._resolve_full_name(cluster_name, instance_tags)
+                        added_tags = instance_tags.get(full_name, [])
                         add_tags = self.get_bucket_tags_to_add(added_tags, bucket_tags)
                         if self.cluster_name:
                             if self.cluster_name in bucket.get('Name'):

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/run_tag_cluster_resouces.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/run_tag_cluster_resouces.py
@@ -16,7 +16,7 @@ def tag_cluster_resource(cluster_name: str = '', mandatory_tags: dict = None, re
     else:
         action = 'read'
         dry_run = 'yes'
-    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
     tag_cluster_resources = TagClusterResources(cluster_prefix=cluster_prefix, cluster_name=cluster_name,
                                                 input_tags=mandatory_tags, region=region, dry_run=dry_run, cluster_only=cluster_only)
 
@@ -64,7 +64,7 @@ def remove_cluster_resources_tags(region: str, cluster_name: str, input_tags: di
     @param input_tags:
     @return:
     """
-    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
     remove_cluster_tags = RemoveClusterTags(region=region, cluster_name=cluster_name, cluster_prefix=cluster_prefix, input_tags=input_tags, cluster_only=cluster_only)
     func_resource_list = [remove_cluster_tags.cluster_instance,
                           remove_cluster_tags.cluster_volume,

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/run_tag_cluster_resouces.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/run_tag_cluster_resouces.py
@@ -1,4 +1,5 @@
 from cloud_governance.common.logger.init_logger import logger
+from cloud_governance.main.environment_variables import environment_variables
 from cloud_governance.policy.policy_operations.aws.tag_cluster.remove_cluster_tags import RemoveClusterTags
 from cloud_governance.policy.policy_operations.aws.tag_cluster.tag_cluster_resouces import TagClusterResources
 
@@ -15,7 +16,8 @@ def tag_cluster_resource(cluster_name: str = '', mandatory_tags: dict = None, re
     else:
         action = 'read'
         dry_run = 'yes'
-    tag_cluster_resources = TagClusterResources(cluster_prefix=["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"], cluster_name=cluster_name,
+    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', [])
+    tag_cluster_resources = TagClusterResources(cluster_prefix=cluster_prefix, cluster_name=cluster_name,
                                                 input_tags=mandatory_tags, region=region, dry_run=dry_run, cluster_only=cluster_only)
 
     func_resource_list = [tag_cluster_resources.cluster_instance,
@@ -62,7 +64,8 @@ def remove_cluster_resources_tags(region: str, cluster_name: str, input_tags: di
     @param input_tags:
     @return:
     """
-    remove_cluster_tags = RemoveClusterTags(region=region, cluster_name=cluster_name, cluster_prefix='kubernetes.io/cluster/', input_tags=input_tags, cluster_only=cluster_only)
+    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', [])
+    remove_cluster_tags = RemoveClusterTags(region=region, cluster_name=cluster_name, cluster_prefix=cluster_prefix, input_tags=input_tags, cluster_only=cluster_only)
     func_resource_list = [remove_cluster_tags.cluster_instance,
                           remove_cluster_tags.cluster_volume,
                           remove_cluster_tags.cluster_images,

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/run_tag_cluster_resouces.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/run_tag_cluster_resouces.py
@@ -16,7 +16,7 @@ def tag_cluster_resource(cluster_name: str = '', mandatory_tags: dict = None, re
     else:
         action = 'read'
         dry_run = 'yes'
-    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', [])
+    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
     tag_cluster_resources = TagClusterResources(cluster_prefix=cluster_prefix, cluster_name=cluster_name,
                                                 input_tags=mandatory_tags, region=region, dry_run=dry_run, cluster_only=cluster_only)
 
@@ -64,7 +64,7 @@ def remove_cluster_resources_tags(region: str, cluster_name: str, input_tags: di
     @param input_tags:
     @return:
     """
-    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', [])
+    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
     remove_cluster_tags = RemoveClusterTags(region=region, cluster_name=cluster_name, cluster_prefix=cluster_prefix, input_tags=input_tags, cluster_only=cluster_only)
     func_resource_list = [remove_cluster_tags.cluster_instance,
                           remove_cluster_tags.cluster_volume,

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_operations.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_operations.py
@@ -157,7 +157,7 @@ class TagClusterOperations:
             for item in instance_group:
                 tags = item.get('Tags', [])
                 for tag in tags:
-                    if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                    if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                         if cluster_name in tag.get('Key', ''):
                             user = self.ec2_operations.get_tag_value_from_tags(
                                 tags=tags, tag_name='User')

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_operations.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_operations.py
@@ -16,7 +16,7 @@ class TagClusterOperations:
 
     CLUSTER_ID_COST_ALLOCATION_TAG = 'cluster_id'
 
-    def __init__(self, region: str, input_tags: dict = None,  cluster_name: str = None,  cluster_prefix: str = None, dry_run: str = None, cluster_only: bool = None):
+    def __init__(self, region: str, input_tags: dict = None,  cluster_name: str = None,  cluster_prefix: list = None, dry_run: str = None, cluster_only: bool = None):
         self.cluster_only = cluster_only
         self.cluster_prefix = cluster_prefix
         self.utils = Utils(region=region)

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_resouces.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_resouces.py
@@ -110,7 +110,7 @@ class TagClusterResources(TagClusterOperations):
                             if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
                                 if cluster_name in tag.get('Key'):
                                     # Propagation-blocked prefixes derived from CLUSTER_PREFIX (e.g. kubernetes.io/, sigs.k8s.io/)
-                                    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', [])
+                                    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
                                     no_propagate_prefixes = tuple(p.split('/', 1)[0] + '/' for p in cluster_prefix)
                                     i_tags = [instance_tag for instance_tag in item.get('Tags') if
                                               instance_tag.get('Key') != 'Name' and
@@ -590,7 +590,7 @@ class TagClusterResources(TagClusterOperations):
         """
         if vpcs_data is None:
             vpcs_data = self.ec2_operations.get_vpcs()
-        cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', [])
+        cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         no_propagate_prefixes = tuple(p.split('/', 1)[0] + '/' for p in cluster_prefix)
         vpc_ids = {}
         for vpc in vpcs_data:

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_resouces.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_resouces.py
@@ -110,7 +110,7 @@ class TagClusterResources(TagClusterOperations):
                             if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                                 if cluster_name in tag.get('Key'):
                                     # Propagation-blocked prefixes derived from CLUSTER_PREFIX (e.g. kubernetes.io/, sigs.k8s.io/)
-                                    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+                                    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
                                     no_propagate_prefixes = tuple(p.split('/', 1)[0] + '/' for p in cluster_prefix)
                                     i_tags = [instance_tag for instance_tag in item.get('Tags') if
                                               instance_tag.get('Key') != 'Name' and
@@ -590,7 +590,7 @@ class TagClusterResources(TagClusterOperations):
         """
         if vpcs_data is None:
             vpcs_data = self.ec2_operations.get_vpcs()
-        cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         no_propagate_prefixes = tuple(p.split('/', 1)[0] + '/' for p in cluster_prefix)
         vpc_ids = {}
         for vpc in vpcs_data:

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_resouces.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_resouces.py
@@ -114,7 +114,7 @@ class TagClusterResources(TagClusterOperations):
                                     no_propagate_prefixes = tuple(p.split('/', 1)[0] + '/' for p in cluster_prefix)
                                     i_tags = [instance_tag for instance_tag in item.get('Tags') if
                                               instance_tag.get('Key') != 'Name' and
-                                              not any((instance_tag.get('Key') or '').startswith(prefix)
+                                              not any((instance_tag.get('Key') or '').startswith(f'{prefix}/')
                                                       for prefix in self.cluster_prefix) and
                                               not (instance_tag.get('Key') or '').startswith(no_propagate_prefixes)]
                                     return i_tags
@@ -599,7 +599,7 @@ class TagClusterResources(TagClusterOperations):
                     if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                         vpc_ids[vpc.get('VpcId')] = [t for t in vpc.get('Tags') if
                                                      t.get('Key') != 'Name' and
-                                                     not any((t.get('Key') or '').startswith(prefix)
+                                                     not any((t.get('Key') or '').startswith(f'{prefix}/')
                                                              for prefix in self.cluster_prefix) and
                                                      not (t.get('Key') or '').startswith(no_propagate_prefixes)]
                         break

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_resouces.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_resouces.py
@@ -64,7 +64,7 @@ class TagClusterResources(TagClusterOperations):
                 if tag.get('Key') == 'api.openshift.com/name':
                     cluster_name = tag['Value']
                 else:
-                    if not cluster_name and any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                    if not cluster_name and any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                         cluster_name = tag['Key']
             if cluster_name:
                 # cluster_name = cluster_id
@@ -86,7 +86,7 @@ class TagClusterResources(TagClusterOperations):
                 found = True
                 break
         for tag in tags:
-            if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+            if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                 cluster_name = tag['Key']
                 break
         if not found:
@@ -107,7 +107,7 @@ class TagClusterResources(TagClusterOperations):
                 for item in instance:
                     if item.get('Tags'):
                         for tag in item.get('Tags'):
-                            if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                            if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                                 if cluster_name in tag.get('Key'):
                                     # Propagation-blocked prefixes derived from CLUSTER_PREFIX (e.g. kubernetes.io/, sigs.k8s.io/)
                                     cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
@@ -156,7 +156,7 @@ class TagClusterResources(TagClusterOperations):
                 # search that not exist permanent tags in the resource
                 if not self.__validate_existing_tag(resource.get(tags)):
                     for tag in resource[tags]:
-                        if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                        if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                             if tag.get('Key') not in cluster_tags:
                                 cluster_tags[tag.get('Key')] = []
                                 cluster_ids[tag.get('Key')] = []
@@ -208,7 +208,7 @@ class TagClusterResources(TagClusterOperations):
                             None,
                         ) or []
                         cluster_tag = [t for t in raw_vpc_tags if
-                                       any(prefix in t.get('Key', '') for prefix in self.cluster_prefix)]
+                                       any(t.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix)]
                         if all_tags:
                             if self.cluster_name:
                                 if cluster_tag and self.cluster_name in cluster_tag[0].get('Key', ''):
@@ -297,7 +297,7 @@ class TagClusterResources(TagClusterOperations):
                     # search that not exist permanent tags in the resource
                     if not self.__validate_existing_tag(tags):
                         for tag in tags:
-                            if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                            if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                                 add_tags = self.__append_input_tags()
                                 add_tags.append(tag)
                                 cluster_name = tag.get('Key').split('/')[-1]
@@ -489,7 +489,7 @@ class TagClusterResources(TagClusterOperations):
                 if item.get('Tags'):
                     if not self.__validate_existing_tag(item.get('Tags')):
                         for tag in item['Tags']:
-                            if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                            if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                                 all_tags = []
                                 instance_tags = self.__get_cluster_tags_by_instance_cluster(cluster_name=tag.get('Key'))
                                 if not instance_tags:
@@ -537,7 +537,7 @@ class TagClusterResources(TagClusterOperations):
                 if item.get('Tags'):
                     if not self.__validate_existing_tag(item.get('Tags')):
                         for tag in item['Tags']:
-                            if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                            if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                                 all_tags = []
                                 instance_tags = self.__get_cluster_tags_by_instance_cluster(cluster_name=tag.get('Key'))
                                 if not instance_tags:
@@ -596,7 +596,7 @@ class TagClusterResources(TagClusterOperations):
         for vpc in vpcs_data:
             if vpc.get('Tags'):
                 for tag in vpc.get('Tags'):
-                    if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+                    if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                         vpc_ids[vpc.get('VpcId')] = [t for t in vpc.get('Tags') if
                                                      t.get('Key') != 'Name' and
                                                      not any((t.get('Key') or '').startswith(prefix)

--- a/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_resouces.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_cluster/tag_cluster_resouces.py
@@ -110,7 +110,7 @@ class TagClusterResources(TagClusterOperations):
                             if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
                                 if cluster_name in tag.get('Key'):
                                     # Propagation-blocked prefixes derived from CLUSTER_PREFIX (e.g. kubernetes.io/, sigs.k8s.io/)
-                                    cluster_prefix = environment_variables.environment_variables_dict['CLUSTER_PREFIX']
+                                    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', [])
                                     no_propagate_prefixes = tuple(p.split('/', 1)[0] + '/' for p in cluster_prefix)
                                     i_tags = [instance_tag for instance_tag in item.get('Tags') if
                                               instance_tag.get('Key') != 'Name' and
@@ -590,7 +590,7 @@ class TagClusterResources(TagClusterOperations):
         """
         if vpcs_data is None:
             vpcs_data = self.ec2_operations.get_vpcs()
-        cluster_prefix = environment_variables.environment_variables_dict['CLUSTER_PREFIX']
+        cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', [])
         no_propagate_prefixes = tuple(p.split('/', 1)[0] + '/' for p in cluster_prefix)
         vpc_ids = {}
         for vpc in vpcs_data:

--- a/cloud_governance/policy/policy_operations/aws/tag_non_cluster/non_cluster_operations.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_non_cluster/non_cluster_operations.py
@@ -18,7 +18,7 @@ class NonClusterOperations:
         self.dry_run = dry_run
         self.input_tags = input_tags
         self.cloudtrail = boto3.client('cloudtrail', region_name=region)
-        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
+        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         self.ec2_client = boto3.client('ec2', region_name=region)
         self.cloudtrail = CloudTrailOperations(region_name=self.region)
         self.iam_client = IAMOperations()

--- a/cloud_governance/policy/policy_operations/aws/tag_non_cluster/non_cluster_operations.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_non_cluster/non_cluster_operations.py
@@ -6,6 +6,7 @@ from cloud_governance.common.clouds.aws.cloudtrail.cloudtrail_operations import 
 from cloud_governance.common.clouds.aws.ec2.ec2_operations import EC2Operations
 from cloud_governance.common.clouds.aws.iam.iam_operations import IAMOperations
 from cloud_governance.common.clouds.aws.utils.utils import Utils
+from cloud_governance.main.environment_variables import environment_variables
 
 
 class NonClusterOperations:
@@ -17,7 +18,7 @@ class NonClusterOperations:
         self.dry_run = dry_run
         self.input_tags = input_tags
         self.cloudtrail = boto3.client('cloudtrail', region_name=region)
-        self.cluster_prefix = 'kubernetes.io/cluster/'
+        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
         self.ec2_client = boto3.client('ec2', region_name=region)
         self.cloudtrail = CloudTrailOperations(region_name=self.region)
         self.iam_client = IAMOperations()

--- a/cloud_governance/policy/policy_operations/aws/tag_non_cluster/non_cluster_operations.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_non_cluster/non_cluster_operations.py
@@ -18,7 +18,7 @@ class NonClusterOperations:
         self.dry_run = dry_run
         self.input_tags = input_tags
         self.cloudtrail = boto3.client('cloudtrail', region_name=region)
-        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         self.ec2_client = boto3.client('ec2', region_name=region)
         self.cloudtrail = CloudTrailOperations(region_name=self.region)
         self.iam_client = IAMOperations()

--- a/cloud_governance/policy/policy_operations/aws/tag_user/remove_user_tags.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_user/remove_user_tags.py
@@ -14,7 +14,7 @@ class RemoveUserTags:
     def __init__(self, remove_keys: list, username: str = ''):
         self.remove_keys = remove_keys
         self.username = username
-        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
+        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         self.iam_client = boto3.client('iam')
         self.IAMOperations = IAMOperations()
         self.get_detail_resource_list = Utils().get_details_resource_list
@@ -26,7 +26,7 @@ class RemoveUserTags:
         @return:
         """
         for tag in tags:
-            if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+            if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                 return True
         return False
 

--- a/cloud_governance/policy/policy_operations/aws/tag_user/remove_user_tags.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_user/remove_user_tags.py
@@ -14,7 +14,7 @@ class RemoveUserTags:
     def __init__(self, remove_keys: list, username: str = ''):
         self.remove_keys = remove_keys
         self.username = username
-        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         self.iam_client = boto3.client('iam')
         self.IAMOperations = IAMOperations()
         self.get_detail_resource_list = Utils().get_details_resource_list

--- a/cloud_governance/policy/policy_operations/aws/tag_user/remove_user_tags.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_user/remove_user_tags.py
@@ -3,6 +3,7 @@ import boto3
 from cloud_governance.common.clouds.aws.iam.iam_operations import IAMOperations
 from cloud_governance.common.clouds.aws.utils.utils import Utils
 from cloud_governance.common.logger.init_logger import logger
+from cloud_governance.main.environment_variables import environment_variables
 
 
 class RemoveUserTags:
@@ -13,6 +14,7 @@ class RemoveUserTags:
     def __init__(self, remove_keys: list, username: str = ''):
         self.remove_keys = remove_keys
         self.username = username
+        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
         self.iam_client = boto3.client('iam')
         self.IAMOperations = IAMOperations()
         self.get_detail_resource_list = Utils().get_details_resource_list
@@ -24,7 +26,7 @@ class RemoveUserTags:
         @return:
         """
         for tag in tags:
-            if 'kubernetes.io/cluster' in tag.get('Key'):
+            if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
                 return True
         return False
 

--- a/cloud_governance/policy/policy_operations/aws/tag_user/tag_iam_user.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_user/tag_iam_user.py
@@ -23,7 +23,7 @@ class TagUser:
 
     def __init__(self, file_name: str):
         self.__environment_variables_dict = environment_variables.environment_variables_dict
-        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         self.iam_client = boto3.client('iam')
         self.get_detail_resource_list = Utils().get_details_resource_list
         self.IAMOperations = IAMOperations()

--- a/cloud_governance/policy/policy_operations/aws/tag_user/tag_iam_user.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_user/tag_iam_user.py
@@ -23,6 +23,7 @@ class TagUser:
 
     def __init__(self, file_name: str):
         self.__environment_variables_dict = environment_variables.environment_variables_dict
+        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
         self.iam_client = boto3.client('iam')
         self.get_detail_resource_list = Utils().get_details_resource_list
         self.IAMOperations = IAMOperations()
@@ -48,7 +49,7 @@ class TagUser:
         @return:
         """
         for tag in tags:
-            if 'kubernetes.io/cluster' in tag.get('Key'):
+            if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
                 return True
         return False
 

--- a/cloud_governance/policy/policy_operations/aws/tag_user/tag_iam_user.py
+++ b/cloud_governance/policy/policy_operations/aws/tag_user/tag_iam_user.py
@@ -23,7 +23,7 @@ class TagUser:
 
     def __init__(self, file_name: str):
         self.__environment_variables_dict = environment_variables.environment_variables_dict
-        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
+        self.cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         self.iam_client = boto3.client('iam')
         self.get_detail_resource_list = Utils().get_details_resource_list
         self.IAMOperations = IAMOperations()
@@ -49,7 +49,7 @@ class TagUser:
         @return:
         """
         for tag in tags:
-            if any(prefix in tag.get('Key', '') for prefix in self.cluster_prefix):
+            if any(tag.get('Key', '').startswith(f'{prefix}/') for prefix in self.cluster_prefix):
                 return True
         return False
 

--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
@@ -15,7 +15,11 @@ from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterRes
 @typeguard.typechecked
 def __get_resource_list(region, delete: bool = False, resource: str = '', cluster_tag: str = '',
                         resource_name: str = '', service_type: str = ' '):
-    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+    # Exclude hypershift prefix from zombie detection: hypershift control-plane runs in a separate
+    # management account so customer workload accounts have no instances to verify cluster liveness.
+    # Resources in customer accounts use kubernetes.io/ and sigs.k8s.io/ tags (handled by existing prefixes).
+    _all_prefixes = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
+    cluster_prefix = [p for p in _all_prefixes if not p.startswith('hypershift')]
     zombie_cluster_resources = ZombieClusterResources(cluster_prefix=cluster_prefix, delete=delete,
                                                       region=region, cluster_tag=cluster_tag,
                                                       resource_name=resource_name)

--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
@@ -15,7 +15,7 @@ from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterRes
 @typeguard.typechecked
 def __get_resource_list(region, delete: bool = False, resource: str = '', cluster_tag: str = '',
                         resource_name: str = '', service_type: str = ' '):
-    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX')
+    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
     zombie_cluster_resources = ZombieClusterResources(cluster_prefix=cluster_prefix, delete=delete,
                                                       region=region, cluster_tag=cluster_tag,
                                                       resource_name=resource_name)

--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
@@ -15,11 +15,7 @@ from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterRes
 @typeguard.typechecked
 def __get_resource_list(region, delete: bool = False, resource: str = '', cluster_tag: str = '',
                         resource_name: str = '', service_type: str = ' '):
-    # Exclude hypershift prefix from zombie detection: hypershift control-plane runs in a separate
-    # management account so customer workload accounts have no instances to verify cluster liveness.
-    # Resources in customer accounts use kubernetes.io/ and sigs.k8s.io/ tags (handled by existing prefixes).
-    _all_prefixes = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
-    cluster_prefix = [p for p in _all_prefixes if not p.startswith('hypershift')]
+    cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
     zombie_cluster_resources = ZombieClusterResources(cluster_prefix=cluster_prefix, delete=delete,
                                                       region=region, cluster_tag=cluster_tag,
                                                       resource_name=resource_name)

--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/validate_zombies.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/validate_zombies.py
@@ -12,7 +12,7 @@ class ValidateZombies:
 
     def __init__(self, file_path: str, region: str = 'us-east-2'):
         self.ec2_client = boto3.client('ec2', region_name=region)
-        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         self.__get_details_resource_list = Utils().get_details_resource_list
         self.file_path = file_path
         self.all_instances = ZombieClusterResources(region=region, cluster_prefix=self.cluster_prefix).all_cluster_instance

--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/validate_zombies.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/validate_zombies.py
@@ -4,6 +4,7 @@ import boto3
 
 from cloud_governance.common.clouds.aws.utils.utils import Utils
 from cloud_governance.common.logger.init_logger import logger
+from cloud_governance.main.environment_variables import environment_variables
 from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterResources
 
 
@@ -11,7 +12,7 @@ class ValidateZombies:
 
     def __init__(self, file_path: str, region: str = 'us-east-2'):
         self.ec2_client = boto3.client('ec2', region_name=region)
-        self.cluster_prefix = 'kubernetes.io/cluster/'
+        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
         self.__get_details_resource_list = Utils().get_details_resource_list
         self.file_path = file_path
         self.all_instances = ZombieClusterResources(region=region, cluster_prefix=self.cluster_prefix).all_cluster_instance

--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/validate_zombies.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/validate_zombies.py
@@ -12,7 +12,7 @@ class ValidateZombies:
 
     def __init__(self, file_path: str, region: str = 'us-east-2'):
         self.ec2_client = boto3.client('ec2', region_name=region)
-        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
+        self.cluster_prefix = environment_variables.environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         self.__get_details_resource_list = Utils().get_details_resource_list
         self.file_path = file_path
         self.all_instances = ZombieClusterResources(region=region, cluster_prefix=self.cluster_prefix).all_cluster_instance

--- a/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/run_zombie_non_cluster_policies.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/run_zombie_non_cluster_policies.py
@@ -41,7 +41,7 @@ class NonClusterZombiePolicy:
         self._s3_client = boto3.client('s3')
         self._iam_operations = IAMOperations()
         self._iam_client = boto3.client('iam')
-        self._cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
+        self._cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
         self._s3operations = S3Operations(region_name=self._region)
         self._cloudtrail = CloudTrailOperations(region_name=self._region)
         self._special_user_mails = self.__environment_variables_dict.get('special_user_mails', '{}')

--- a/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/run_zombie_non_cluster_policies.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/run_zombie_non_cluster_policies.py
@@ -82,7 +82,7 @@ class NonClusterZombiePolicy:
         """
         if tags:
             for tag in tags:
-                if tag.get('Key').startswith(tuple(self._cluster_prefix)):
+                if tag.get('Key').startswith(tuple(f'{p}/' for p in self._cluster_prefix)):
                     return True
         return False
 

--- a/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/run_zombie_non_cluster_policies.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/run_zombie_non_cluster_policies.py
@@ -41,8 +41,7 @@ class NonClusterZombiePolicy:
         self._s3_client = boto3.client('s3')
         self._iam_operations = IAMOperations()
         self._iam_client = boto3.client('iam')
-        self._cluster_prefix = 'kubernetes.io/cluster'
-        self._zombie_cluster = ZombieClusterResources(cluster_prefix=self._cluster_prefix)
+        self._cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ['kubernetes.io/cluster'])
         self._s3operations = S3Operations(region_name=self._region)
         self._cloudtrail = CloudTrailOperations(region_name=self._region)
         self._special_user_mails = self.__environment_variables_dict.get('special_user_mails', '{}')
@@ -83,7 +82,7 @@ class NonClusterZombiePolicy:
         """
         if tags:
             for tag in tags:
-                if tag.get('Key').startswith(self._cluster_prefix):
+                if tag.get('Key').startswith(tuple(self._cluster_prefix)):
                     return True
         return False
 

--- a/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/run_zombie_non_cluster_policies.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_non_cluster/run_zombie_non_cluster_policies.py
@@ -41,7 +41,7 @@ class NonClusterZombiePolicy:
         self._s3_client = boto3.client('s3')
         self._iam_operations = IAMOperations()
         self._iam_client = boto3.client('iam')
-        self._cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster", "hypershift.openshift.io/cluster"])
+        self._cluster_prefix = self.__environment_variables_dict.get('CLUSTER_PREFIX', ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"])
         self._s3operations = S3Operations(region_name=self._region)
         self._cloudtrail = CloudTrailOperations(region_name=self._region)
         self._special_user_mails = self.__environment_variables_dict.get('special_user_mails', '{}')

--- a/jenkins/clouds/aws/daily/policies/run_policies.py
+++ b/jenkins/clouds/aws/daily/policies/run_policies.py
@@ -94,7 +94,7 @@ container_env_dict = {
     "MANAGER_EMAIL_ALERT": "False", "EMAIL_ALERT": "False", "log_level": "INFO",
     'DAYS_TO_TAKE_ACTION': days_to_delete_resource, 'special_user_mails': f"{special_user_mails}",
     'account_admin': f"{account_admin}",
-    'CLUSTER_PREFIX': '["kubernetes.io/cluster","sigs.k8s.io/cluster-api-provider-aws/cluster","hypershift.openshift.io/cluster"]'
+    'CLUSTER_PREFIX': '["kubernetes.io/cluster","sigs.k8s.io/cluster-api-provider-aws/cluster"]'
 }
 
 

--- a/jenkins/clouds/aws/daily/policies/run_policies.py
+++ b/jenkins/clouds/aws/daily/policies/run_policies.py
@@ -94,7 +94,7 @@ container_env_dict = {
     "MANAGER_EMAIL_ALERT": "False", "EMAIL_ALERT": "False", "log_level": "INFO",
     'DAYS_TO_TAKE_ACTION': days_to_delete_resource, 'special_user_mails': f"{special_user_mails}",
     'account_admin': f"{account_admin}",
-    'CLUSTER_PREFIX': '["kubernetes.io/cluster","sigs.k8s.io/cluster-api-provider-aws/cluster"]'
+    'CLUSTER_PREFIX': '["kubernetes.io/cluster","sigs.k8s.io/cluster-api-provider-aws/cluster","hypershift.openshift.io/cluster"]'
 }
 
 

--- a/jenkins/tenant/aws/common/run_policies.py
+++ b/jenkins/tenant/aws/common/run_policies.py
@@ -98,7 +98,7 @@ container_env_dict = {
     "ES_SERVER_TYPE": ES_SERVER_TYPE,
     "MANAGER_EMAIL_ALERT": "False", "EMAIL_ALERT": "False", "log_level": "INFO",
     'DAYS_TO_TAKE_ACTION': days_to_delete_resource, 'ALERT_DRY_RUN': ALERT_DRY_RUN,
-    'CLUSTER_PREFIX': '["kubernetes.io/cluster","sigs.k8s.io/cluster-api-provider-aws/cluster"]'
+    'CLUSTER_PREFIX': '["kubernetes.io/cluster","sigs.k8s.io/cluster-api-provider-aws/cluster","hypershift.openshift.io/cluster"]'
 }
 
 

--- a/jenkins/tenant/aws/common/run_policies.py
+++ b/jenkins/tenant/aws/common/run_policies.py
@@ -98,7 +98,7 @@ container_env_dict = {
     "ES_SERVER_TYPE": ES_SERVER_TYPE,
     "MANAGER_EMAIL_ALERT": "False", "EMAIL_ALERT": "False", "log_level": "INFO",
     'DAYS_TO_TAKE_ACTION': days_to_delete_resource, 'ALERT_DRY_RUN': ALERT_DRY_RUN,
-    'CLUSTER_PREFIX': '["kubernetes.io/cluster","sigs.k8s.io/cluster-api-provider-aws/cluster","hypershift.openshift.io/cluster"]'
+    'CLUSTER_PREFIX': '["kubernetes.io/cluster","sigs.k8s.io/cluster-api-provider-aws/cluster"]'
 }
 
 

--- a/tests/unittest/cloud_governance/aws/tag_cluster/test_tag_cluster_operations.py
+++ b/tests/unittest/cloud_governance/aws/tag_cluster/test_tag_cluster_operations.py
@@ -75,7 +75,7 @@ class TestTagClusterOperationsGetUsername:
 class TestTagClusterOperationsClusterInstanceFallback:
     def test_get_username_from_cluster_instances_returns_tagged_peer(self):
         ops = TagClusterOperations.__new__(TagClusterOperations)
-        ops.cluster_prefix = ['kubernetes.io/cluster/']
+        ops.cluster_prefix = ['kubernetes.io/cluster']
         ops.iam_users = [CLUSTER_OWNER]
         ops.ec2_operations = Mock()
         ops.ec2_operations.get_tag_value_from_tags = Mock(return_value=CLUSTER_OWNER)

--- a/tests/unittest/cloud_governance/aws/tag_user/test_remove_user_tags.py
+++ b/tests/unittest/cloud_governance/aws/tag_user/test_remove_user_tags.py
@@ -15,3 +15,24 @@ def test_remove_user_tags():
     iam_client.create_user(UserName='test-user2', Tags=[{'Key': 'Username', 'Value': 'test-use1r'}])
     remove_tags = RemoveUserTags(remove_keys=['Username'])
     assert remove_tags.user_tags_remove() == 2
+
+
+@mock_aws
+def test_capa_cluster_user_protected_from_tag_removal():
+    """
+    This test verifies that a user tagged with a CAPA cluster key is identified
+    as a cluster service account and protected from governance tag removal.
+    @return:
+    """
+    iam_client = boto3.client('iam')
+    capa_cluster_tag = 'sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster'
+    iam_client.create_user(
+        UserName='capa-sa-user',
+        Tags=[
+            {'Key': capa_cluster_tag, 'Value': 'owned'},
+            {'Key': 'Username', 'Value': 'capa-sa-user'},
+        ]
+    )
+    remove_tags = RemoveUserTags(remove_keys=['Username'])
+    removed_count = remove_tags.user_tags_remove()
+    assert removed_count == 0

--- a/tests/unittest/cloud_governance/aws/tag_user/test_tag_iam_user.py
+++ b/tests/unittest/cloud_governance/aws/tag_user/test_tag_iam_user.py
@@ -53,3 +53,29 @@ def test_update_user_tags():
     count = tag_user.update_user_tags()
     os.remove(file_name)
     assert count == 1
+
+
+@mock_aws
+def test_capa_cluster_user_excluded_from_csv():
+    """
+    This test verifies that a user tagged with a CAPA cluster key is identified
+    as a cluster service account and excluded from the tagging CSV.
+    @return:
+    """
+    iam_client = boto3.client('iam')
+    capa_cluster_tag = 'sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster'
+    iam_client.create_user(
+        UserName='capa-service-account',
+        Tags=[{'Key': capa_cluster_tag, 'Value': 'owned'}]
+    )
+    tag_user = TagUser(file_name=file_name)
+    tag_user.generate_user_csv()
+
+    row_count = 0
+    if os.path.exists(file_name):
+        with open(file_name, 'r') as f:
+            rows = [r for r in csv.reader(f) if any(cell.strip() for cell in r)]
+        row_count = max(0, len(rows) - 1)  # exclude header
+        os.remove(file_name)
+
+    assert row_count == 0

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_detection.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_detection.py
@@ -521,10 +521,10 @@ def test_f4_stale_counter_reset_for_alive_resource():
     assert delete_days == '0', f"Expected ClusterDeleteDays=0 for alive resource, got {delete_days!r}"
 
 
-def test_hypershift_prefix_in_default_cluster_prefix():
+def test_default_cluster_prefix_contains_ipi_and_capa():
     """
     This test verifies that the built-in default CLUSTER_PREFIX includes
-    'hypershift.openshift.io/cluster' for tag_cluster and cleanup policies.
+    both the IPI and CAPA prefixes.
     """
     import os
     from cloud_governance.main.environment_variables import EnvironmentVariables
@@ -532,7 +532,8 @@ def test_hypershift_prefix_in_default_cluster_prefix():
     try:
         ev = EnvironmentVariables()
         prefix = ev.environment_variables_dict.get('CLUSTER_PREFIX', [])
-        assert 'hypershift.openshift.io/cluster' in prefix
+        assert 'kubernetes.io/cluster' in prefix
+        assert 'sigs.k8s.io/cluster-api-provider-aws/cluster' in prefix
     finally:
         if prev is not None:
             os.environ['CLUSTER_PREFIX'] = prev

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_detection.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_detection.py
@@ -519,3 +519,45 @@ def test_f4_stale_counter_reset_for_alive_resource():
     sg_tags = ec2_client.describe_security_groups(GroupIds=[sg_id])['SecurityGroups'][0].get('Tags', [])
     delete_days = next((t['Value'] for t in sg_tags if t['Key'] == 'ClusterDeleteDays'), None)
     assert delete_days == '0', f"Expected ClusterDeleteDays=0 for alive resource, got {delete_days!r}"
+
+
+def test_hypershift_prefix_in_default_cluster_prefix():
+    """
+    This test verifies that the built-in default CLUSTER_PREFIX includes
+    'hypershift.openshift.io/cluster' for self-managed Hypershift support.
+    """
+    import os
+    from cloud_governance.main.environment_variables import EnvironmentVariables
+    prev = os.environ.pop('CLUSTER_PREFIX', None)
+    try:
+        ev = EnvironmentVariables()
+        prefix = ev.environment_variables_dict.get('CLUSTER_PREFIX', [])
+        assert 'hypershift.openshift.io/cluster' in prefix
+    finally:
+        if prev is not None:
+            os.environ['CLUSTER_PREFIX'] = prev
+
+
+@mock_aws
+def test_sg_with_hypershift_managed_policy_not_zombie():
+    """
+    This test verifies that a security group tagged Policy=hypershift-managed
+    is not classified as a zombie resource even when the VPC has no running instances.
+    """
+    ec2_client = boto3.client('ec2', region_name=REGION)
+
+    vpc_id = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')['Vpc']['VpcId']
+    sg = ec2_client.create_security_group(
+        VpcId=vpc_id, GroupName='hypershift-sg', Description='Hypershift managed SG',
+        TagSpecifications=[{'ResourceType': 'security-group',
+                            'Tags': [
+                                {'Key': K8S_TAG, 'Value': 'owned'},
+                                {'Key': 'Policy', 'Value': 'hypershift-managed'},
+                            ]}]
+    )
+    sg_id = sg['GroupId']
+
+    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
+    zombies, _ = zcr.zombie_cluster_security_group()
+
+    assert sg_id not in zombies

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_detection.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_detection.py
@@ -524,7 +524,7 @@ def test_f4_stale_counter_reset_for_alive_resource():
 def test_hypershift_prefix_in_default_cluster_prefix():
     """
     This test verifies that the built-in default CLUSTER_PREFIX includes
-    'hypershift.openshift.io/cluster' for self-managed Hypershift support.
+    'hypershift.openshift.io/cluster' for tag_cluster and cleanup policies.
     """
     import os
     from cloud_governance.main.environment_variables import EnvironmentVariables
@@ -536,28 +536,3 @@ def test_hypershift_prefix_in_default_cluster_prefix():
     finally:
         if prev is not None:
             os.environ['CLUSTER_PREFIX'] = prev
-
-
-@mock_aws
-def test_sg_with_hypershift_managed_policy_not_zombie():
-    """
-    This test verifies that a security group tagged Policy=hypershift-managed
-    is not classified as a zombie resource even when the VPC has no running instances.
-    """
-    ec2_client = boto3.client('ec2', region_name=REGION)
-
-    vpc_id = ec2_client.create_vpc(CidrBlock='10.0.0.0/16')['Vpc']['VpcId']
-    sg = ec2_client.create_security_group(
-        VpcId=vpc_id, GroupName='hypershift-sg', Description='Hypershift managed SG',
-        TagSpecifications=[{'ResourceType': 'security-group',
-                            'Tags': [
-                                {'Key': K8S_TAG, 'Value': 'owned'},
-                                {'Key': 'Policy', 'Value': 'hypershift-managed'},
-                            ]}]
-    )
-    sg_id = sg['GroupId']
-
-    zcr = ZombieClusterResources(cluster_prefix=CLUSTER_PREFIX, delete=False, region=REGION)
-    zombies, _ = zcr.zombie_cluster_security_group()
-
-    assert sg_id not in zombies

--- a/tests/unittest/cloud_governance/policy/helpers/aws/test_aws_policy_operations.py
+++ b/tests/unittest/cloud_governance/policy/helpers/aws/test_aws_policy_operations.py
@@ -192,3 +192,36 @@ def test_update_resource_day_count_tag_updated_tag_today():
         instances = ec2_client.describe_instances()['Reservations']
         tag_value = aws_cleanup_operations.get_tag_name_from_tags(instances[0]['Instances'][0].get('Tags'), tag_name='DaysCount')
         assert tag_value == str(datetime.datetime.now(tz=datetime.timezone.utc).date()) + "@1"
+
+
+@mock_aws
+def test_get_cluster_tag_with_capa_prefix():
+    """
+    This test verifies that _get_cluster_tag recognises CAPA-prefixed cluster tags
+    in addition to the standard IPI prefix.
+    @return:
+    """
+    aws_ops = AWSPolicyOperations()
+    capa_tags = [{'Key': 'sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster', 'Value': 'owned'}]
+    result = aws_ops._get_cluster_tag(tags=capa_tags)
+    assert result == 'sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster'
+
+
+@mock_aws
+def test_get_active_cluster_ids_includes_capa_instances():
+    """
+    This test verifies that _get_active_cluster_ids finds instances tagged with
+    the CAPA cluster prefix so cleanup policies correctly skip active CAPA resources.
+    @return:
+    """
+    environment_variables.environment_variables_dict['AWS_DEFAULT_REGION'] = 'us-east-2'
+    ec2_client = boto3.client('ec2', region_name='us-east-2')
+    capa_cluster_tag = 'sigs.k8s.io/cluster-api-provider-aws/cluster/test-capa-cluster'
+    ec2_client.run_instances(
+        ImageId='ami-03cf127a', MinCount=1, MaxCount=1,
+        TagSpecifications=[{'ResourceType': 'instance',
+                            'Tags': [{'Key': capa_cluster_tag, 'Value': 'owned'}]}]
+    )
+    aws_ops = AWSPolicyOperations()
+    cluster_ids = aws_ops._get_active_cluster_ids()
+    assert capa_cluster_tag in cluster_ids


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Extends cluster prefix recognition from IPI-only to IPI, CAPA, and self-managed Hypershift across all policies by reading CLUSTER_PREFIX from the environment variable instead of hardcoding kubernetes.io/cluster.

Changes:
- Read CLUSTER_PREFIX from env var in tag_cluster, remove_cluster_tags, NonClusterZombiePolicy, validate_zombies, aws/azure_policy_operations, tag_iam_user, remove_user_tags, CRO monitors (AWS + Azure), and run_tag_cluster_resouces. Removes dead code _zombie_cluster instantiation.
- Add hypershift.openshift.io/cluster to the default CLUSTER_PREFIX list and update Jenkins scripts to include the new prefix.
- Add _is_hypershift_managed() to ZombieClusterResources; resources tagged Policy=hypershift-managed are skipped at all 8 zombie detection intercepts including the VPC-expansion fallback path.
- Fix remove_cluster_tags.py to handle list-typed cluster_prefix at all 13 usage sites; add _resolve_full_name() helper for dict lookups.
- Add unit tests for CAPA/Hypershift prefix recognition in cleanup policies, user tagging, and zombie detection.


## For security reasons, all pull requests need to be approved first before running any automated CI
