### PR TITLE
Enable zombie_cluster_resource in dry_run=no for perf accounts

### DIFF
--- a/jenkins/clouds/aws/daily/policies/Jenkinsfile
+++ b/jenkins/clouds/aws/daily/policies/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
     environment {
         QUAY_CLOUD_GOVERNANCE_REPOSITORY = credentials('QUAY_CLOUD_GOVERNANCE_REPOSITORY')
-        POLICIES_IN_ACTION = '["instance_idle", "ec2_stop", "unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "delete_access_key"]'
+        POLICIES_IN_ACTION = '["instance_idle", "ec2_stop", "unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "delete_access_key", "zombie_cluster_resource"]'
         AWS_IAM_USER_SPREADSHEET_ID = credentials('cloud-governance-aws-iam-user-spreadsheet-id')
         GOOGLE_APPLICATION_CREDENTIALS = credentials('cloud-governance-google-application-credentials')
         LDAP_HOST_NAME = credentials('cloud-governance-ldap-host-name')


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [x] dependencies

## Description
Add zombie_cluster_resource to POLICIES_IN_ACTION. Policy has been running with dry_run=yes across all three accounts with zero false positives confirmed via AWS API verification.

## For security reasons, all pull requests need to be approved first before running any automated CI
