### PR TITLE
Fix alert field priority and replace bare excepts in zombie cluster

### DIFF
--- a/cloud_governance/policy/common_policies/send_aggregated_alerts.py
+++ b/cloud_governance/policy/common_policies/send_aggregated_alerts.py
@@ -139,9 +139,9 @@ class SendAggregatedAlerts:
         filtered_policy_es_data = []
         for record in policy_es_data:
             try:
-                days = record.get('ClusterResourcesCount')
+                days = record.get('CleanUpDays')
                 if not days:
-                    days = record.get('CleanUpDays')
+                    days = record.get('ClusterResourcesCount')
                 if not days:
                     days = record.get('Days')
                 if not days:

--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/zombie_cluster_common_methods.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/zombie_cluster_common_methods.py
@@ -90,21 +90,24 @@ class ZombieClusterCommonMethods:
                     aws_tags = self.elb_client.describe_tags(LoadBalancerNames=[resource_id]).get('TagDescriptions')
                     if len(aws_tags) > 0:
                         aws_tags = aws_tags[0].get(aws_tag)
-                except:
+                except Exception as err:
+                    logger.info(f'elbv1 describe_tags error for {resource_id}: {err}')
                     return []
             elif aws_service == 'elbv2':
                 try:
                     aws_tags = self.elbv2_client.describe_tags(ResourceArns=[resource_id]).get('TagDescriptions')
                     if len(aws_tags) > 0:
                         aws_tags = aws_tags[0].get(aws_tag)
-                except:
+                except Exception as err:
+                    logger.info(f'elbv2 describe_tags error for {resource_id}: {err}')
                     return []
             elif aws_service == 'role' and resource_id in zombies:
                 try:
                     role_data = self.iam_client.get_role(RoleName=resource_id)['Role']
                     if role_data.get(aws_tag):
                         aws_tags = role_data.get(aws_tag)
-                except:
+                except Exception as err:
+                    logger.info(f'iam get_role error for {resource_id}: {err}')
                     return []
             elif aws_service == 'user' and resource_id in zombies:
                 try:
@@ -112,6 +115,7 @@ class ZombieClusterCommonMethods:
                     if user_data.get(aws_tag):
                         aws_tags = user_data.get(aws_tag)
                 except Exception as err:
+                    logger.info(f'iam get_user error for {resource_id}: {err}')
                     return []
             elif aws_service == 'bucket' and resource_id in zombies:
                 try:
@@ -119,6 +123,7 @@ class ZombieClusterCommonMethods:
                     if bucket_data.get(aws_tag):
                         aws_tags = bucket_data.get(aws_tag)
                 except Exception as err:
+                    logger.info(f's3 get_bucket_tagging error for {resource_id}: {err}')
                     return []
             else:
                 if resource.get(aws_tag):
@@ -160,7 +165,8 @@ class ZombieClusterCommonMethods:
                             self.iam_client.tag_user(UserName=resource_id, Tags=tags)
                         elif aws_service == 'bucket':
                             self.s3_client.put_bucket_tagging(Bucket=resource_id, Tagging={'TagSet': tags})
-                    except:
+                    except Exception as err:
+                        logger.info(f'resource tag update error for {resource_id}: {err}')
                         return []
                 if resource_id in zombies:
                     resources_tags[resource_id] = tags

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_common_methods.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_cluster_common_methods.py
@@ -1,0 +1,140 @@
+import logging
+from unittest.mock import patch, MagicMock
+
+import boto3
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from cloud_governance.main.environment_variables import environment_variables
+from cloud_governance.policy.policy_operations.aws.zombie_cluster.zombie_cluster_common_methods import \
+    ZombieClusterCommonMethods
+
+
+def _make_instance(region='us-east-1'):
+    environment_variables.environment_variables_dict['dry_run'] = 'yes'
+    environment_variables.environment_variables_dict['policy'] = 'zombie_cluster_resource'
+    environment_variables.environment_variables_dict['LDAP_HOST_NAME'] = ''
+    environment_variables.environment_variables_dict['DAYS_TO_DELETE_RESOURCE'] = 7
+    with mock_aws():
+        return ZombieClusterCommonMethods(region=region)
+
+
+@mock_aws
+def test_get_tags_of_zombie_resources_elbv1_error_logs(caplog):
+    environment_variables.environment_variables_dict['dry_run'] = 'yes'
+    environment_variables.environment_variables_dict['policy'] = 'zombie_cluster_resource'
+    environment_variables.environment_variables_dict['LDAP_HOST_NAME'] = ''
+    environment_variables.environment_variables_dict['DAYS_TO_DELETE_RESOURCE'] = 7
+    zcm = ZombieClusterCommonMethods(region='us-east-1')
+    zcm.elb_client = MagicMock()
+    zcm.elb_client.describe_tags.side_effect = ClientError(
+        {'Error': {'Code': 'LoadBalancerNotFound', 'Message': 'not found'}}, 'DescribeTags')
+    resources = [{'LoadBalancerName': 'test-lb'}]
+    with caplog.at_level(logging.INFO):
+        result = zcm._get_tags_of_zombie_resources(
+            resources=resources, resource_id_name='LoadBalancerName',
+            zombies={'test-lb': 'cluster-tag'}, aws_service='elbv1')
+    assert result == []
+    assert 'elbv1 describe_tags error for test-lb' in caplog.text
+
+
+@mock_aws
+def test_get_tags_of_zombie_resources_elbv2_error_logs(caplog):
+    environment_variables.environment_variables_dict['dry_run'] = 'yes'
+    environment_variables.environment_variables_dict['policy'] = 'zombie_cluster_resource'
+    environment_variables.environment_variables_dict['LDAP_HOST_NAME'] = ''
+    environment_variables.environment_variables_dict['DAYS_TO_DELETE_RESOURCE'] = 7
+    zcm = ZombieClusterCommonMethods(region='us-east-1')
+    zcm.elbv2_client = MagicMock()
+    zcm.elbv2_client.describe_tags.side_effect = ClientError(
+        {'Error': {'Code': 'LoadBalancerNotFound', 'Message': 'not found'}}, 'DescribeTags')
+    resources = [{'ResourceArn': 'arn:aws:elasticloadbalancing:us-east-1:123456:loadbalancer/test'}]
+    with caplog.at_level(logging.INFO):
+        result = zcm._get_tags_of_zombie_resources(
+            resources=resources, resource_id_name='ResourceArn',
+            zombies={'arn:aws:elasticloadbalancing:us-east-1:123456:loadbalancer/test': 'cluster-tag'},
+            aws_service='elbv2')
+    assert result == []
+    assert 'elbv2 describe_tags error' in caplog.text
+
+
+@mock_aws
+def test_get_tags_of_zombie_resources_role_error_logs(caplog):
+    environment_variables.environment_variables_dict['dry_run'] = 'yes'
+    environment_variables.environment_variables_dict['policy'] = 'zombie_cluster_resource'
+    environment_variables.environment_variables_dict['LDAP_HOST_NAME'] = ''
+    environment_variables.environment_variables_dict['DAYS_TO_DELETE_RESOURCE'] = 7
+    zcm = ZombieClusterCommonMethods(region='us-east-1')
+    zcm.iam_client = MagicMock()
+    zcm.iam_client.get_role.side_effect = ClientError(
+        {'Error': {'Code': 'NoSuchEntity', 'Message': 'role not found'}}, 'GetRole')
+    resources = [{'RoleName': 'test-role'}]
+    with caplog.at_level(logging.INFO):
+        result = zcm._get_tags_of_zombie_resources(
+            resources=resources, resource_id_name='RoleName',
+            zombies={'test-role': 'cluster-tag'}, aws_service='role')
+    assert result == []
+    assert 'iam get_role error for test-role' in caplog.text
+
+
+@mock_aws
+def test_get_tags_of_zombie_resources_user_error_logs(caplog):
+    environment_variables.environment_variables_dict['dry_run'] = 'yes'
+    environment_variables.environment_variables_dict['policy'] = 'zombie_cluster_resource'
+    environment_variables.environment_variables_dict['LDAP_HOST_NAME'] = ''
+    environment_variables.environment_variables_dict['DAYS_TO_DELETE_RESOURCE'] = 7
+    zcm = ZombieClusterCommonMethods(region='us-east-1')
+    zcm.iam_client = MagicMock()
+    zcm.iam_client.get_user.side_effect = ClientError(
+        {'Error': {'Code': 'NoSuchEntity', 'Message': 'user not found'}}, 'GetUser')
+    resources = [{'UserName': 'test-user'}]
+    with caplog.at_level(logging.INFO):
+        result = zcm._get_tags_of_zombie_resources(
+            resources=resources, resource_id_name='UserName',
+            zombies={'test-user': 'cluster-tag'}, aws_service='user')
+    assert result == []
+    assert 'iam get_user error for test-user' in caplog.text
+
+
+@mock_aws
+def test_get_tags_of_zombie_resources_bucket_error_logs(caplog):
+    environment_variables.environment_variables_dict['dry_run'] = 'yes'
+    environment_variables.environment_variables_dict['policy'] = 'zombie_cluster_resource'
+    environment_variables.environment_variables_dict['LDAP_HOST_NAME'] = ''
+    environment_variables.environment_variables_dict['DAYS_TO_DELETE_RESOURCE'] = 7
+    zcm = ZombieClusterCommonMethods(region='us-east-1')
+    zcm.s3_client = MagicMock()
+    zcm.s3_client.get_bucket_tagging.side_effect = ClientError(
+        {'Error': {'Code': 'NoSuchTagSet', 'Message': 'no tags'}}, 'GetBucketTagging')
+    resources = [{'BucketName': 'test-bucket'}]
+    with caplog.at_level(logging.INFO):
+        result = zcm._get_tags_of_zombie_resources(
+            resources=resources, resource_id_name='BucketName',
+            zombies={'test-bucket': 'cluster-tag'}, aws_service='bucket')
+    assert result == []
+    assert 's3 get_bucket_tagging error for test-bucket' in caplog.text
+
+
+@mock_aws
+def test_get_tags_of_zombie_resources_tag_update_error_logs(caplog):
+    environment_variables.environment_variables_dict['dry_run'] = 'no'
+    environment_variables.environment_variables_dict['policy'] = 'zombie_cluster_resource'
+    environment_variables.environment_variables_dict['LDAP_HOST_NAME'] = ''
+    environment_variables.environment_variables_dict['DAYS_TO_DELETE_RESOURCE'] = 7
+    zcm = ZombieClusterCommonMethods(region='us-east-1')
+    zcm.ec2_client = MagicMock()
+    zcm.ec2_client.create_tags.side_effect = ClientError(
+        {'Error': {'Code': 'InvalidResourceID', 'Message': 'bad id'}}, 'CreateTags')
+    resources = [{
+        'InstanceId': 'i-12345',
+        'Tags': [
+            {'Key': 'kubernetes.io/cluster/test-cluster', 'Value': 'owned'},
+            {'Key': 'ClusterDeleteDays', 'Value': '1'}
+        ]
+    }]
+    with caplog.at_level(logging.INFO):
+        result = zcm._get_tags_of_zombie_resources(
+            resources=resources, resource_id_name='InstanceId',
+            zombies={'i-12345': 'test-cluster'}, aws_service='ec2')
+    assert result == []
+    assert 'resource tag update error for i-12345' in caplog.text

--- a/tests/unittest/cloud_governance/policy/aws/test_send_aggregated_alerts.py
+++ b/tests/unittest/cloud_governance/policy/aws/test_send_aggregated_alerts.py
@@ -1,0 +1,133 @@
+from unittest.mock import patch, MagicMock
+
+from cloud_governance.main.environment_variables import environment_variables
+from cloud_governance.policy.common_policies.send_aggregated_alerts import SendAggregatedAlerts
+
+
+def _make_alert_instance():
+    environment_variables.environment_variables_dict['DAYS_TO_DELETE_RESOURCE'] = 7
+    environment_variables.environment_variables_dict['EMAIL_TO'] = ''
+    environment_variables.environment_variables_dict['EMAIL_CC'] = []
+    environment_variables.environment_variables_dict['ALERT_DRY_RUN'] = 'yes'
+    environment_variables.environment_variables_dict['SKIP_POLICIES_ALERT'] = []
+    with patch.object(SendAggregatedAlerts, '__init__', lambda self: None):
+        alert = SendAggregatedAlerts()
+        alert._SendAggregatedAlerts__alert_dry_run = 'yes'
+        alert._SendAggregatedAlerts__days_to_delete_resource = 7
+    return alert
+
+
+def test_update_delete_days_uses_cleanup_days_over_cluster_resources_count():
+    alert = _make_alert_instance()
+    record = {
+        'CleanUpDays': 4,
+        'ClusterResourcesCount': 1,
+        'DryRun': 'no',
+        'policy': 'zombie_cluster_resource',
+    }
+    result = alert._SendAggregatedAlerts__update_delete_days([record])
+    assert len(result) == 1
+    assert result[0]['DeleteDate'] != ''
+
+
+def test_update_delete_days_cluster_resources_count_alone_still_works():
+    alert = _make_alert_instance()
+    record = {
+        'ClusterResourcesCount': 4,
+        'DryRun': 'no',
+        'policy': 'zombie_cluster_resource',
+    }
+    result = alert._SendAggregatedAlerts__update_delete_days([record])
+    assert len(result) == 1
+    assert result[0]['DeleteDate'] != ''
+
+
+def test_update_delete_days_falls_through_to_days():
+    alert = _make_alert_instance()
+    record = {
+        'Days': 2,
+        'DryRun': 'no',
+        'policy': 'instance_idle',
+    }
+    result = alert._SendAggregatedAlerts__update_delete_days([record])
+    assert len(result) == 1
+
+
+def test_update_delete_days_falls_through_to_stopped_days():
+    alert = _make_alert_instance()
+    record = {
+        'StoppedDays': 2,
+        'DryRun': 'no',
+        'policy': 'ec2_stop',
+    }
+    result = alert._SendAggregatedAlerts__update_delete_days([record])
+    assert len(result) == 1
+
+
+def test_update_delete_days_dry_run_yes_always_included():
+    alert = _make_alert_instance()
+    record = {
+        'CleanUpDays': 1,
+        'DryRun': 'yes',
+        'policy': 'zombie_cluster_resource',
+    }
+    result = alert._SendAggregatedAlerts__update_delete_days([record])
+    assert len(result) == 1
+    assert result[0]['DeleteDate'] == 'dry_run=yes'
+
+
+def test_update_delete_days_first_alert_threshold():
+    alert = _make_alert_instance()
+    record = {
+        'CleanUpDays': 2,
+        'DryRun': 'no',
+        'policy': 'zombie_cluster_resource',
+    }
+    result = alert._SendAggregatedAlerts__update_delete_days([record])
+    assert len(result) == 1
+    assert result[0].get('DeleteDate') != ''
+
+
+def test_update_delete_days_second_alert_threshold():
+    alert = _make_alert_instance()
+    record = {
+        'CleanUpDays': 4,
+        'DryRun': 'no',
+        'policy': 'zombie_cluster_resource',
+    }
+    result = alert._SendAggregatedAlerts__update_delete_days([record])
+    assert len(result) == 1
+
+
+def test_update_delete_days_deletion_threshold():
+    alert = _make_alert_instance()
+    record = {
+        'CleanUpDays': 7,
+        'DryRun': 'no',
+        'policy': 'zombie_cluster_resource',
+    }
+    result = alert._SendAggregatedAlerts__update_delete_days([record])
+    assert len(result) == 1
+
+
+def test_update_delete_days_no_alert_between_thresholds():
+    alert = _make_alert_instance()
+    record = {
+        'CleanUpDays': 3,
+        'DryRun': 'no',
+        'policy': 'zombie_cluster_resource',
+    }
+    result = alert._SendAggregatedAlerts__update_delete_days([record])
+    assert len(result) == 0
+
+
+def test_update_delete_days_skip_policy_gets_skip_delete():
+    alert = _make_alert_instance()
+    record = {
+        'CleanUpDays': 3,
+        'DryRun': 'no',
+        'SkipPolicy': 'NOTDELETE',
+        'policy': 'zombie_cluster_resource',
+    }
+    result = alert._SendAggregatedAlerts__update_delete_days([record])
+    assert len(result) == 0


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Check CleanUpDays before ClusterResourcesCount in send_aggregated_alerts so zombie_cluster_resource alerts fire on the actual day counter instead of the resource type count. Replace bare except blocks in zombie_cluster_common_methods with except Exception and add logger.info so errors are visible in logs.


## For security reasons, all pull requests need to be approved first before running any automated CI
