### PR TITLE
Move orion_metrics_rollup to common_policies

### DIFF
--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -106,7 +106,7 @@ class EnvironmentVariables:
         es_index = 'cloud-governance-policy-es-index'
         self._environment_variables_dict['cost_policies'] = ['cost_explorer', 'cost_over_usage', 'cost_billing_reports',
                                                              'cost_explorer_payer_billings', 'spot_savings_analysis',
-                                                             'yearly_savings_report', 'orion_metrics_rollup']
+                                                             'yearly_savings_report']
         self._environment_variables_dict['ibm_policies'] = ['tag_baremetal', 'tag_vm', 'ibm_cost_report',
                                                             'ibm_cost_over_usage']
         self._environment_variables_dict['azure_policies'] = ['tag_azure_resource_group']
@@ -305,7 +305,7 @@ class EnvironmentVariables:
         self._environment_variables_dict['ADMIN_MAIL_LIST'] = EnvironmentVariables.get_env('ADMIN_MAIL_LIST', '')
         self._environment_variables_dict['SKIP_POLICIES_ALERT'] = literal_eval(
             EnvironmentVariables.get_env('SKIP_POLICIES_ALERT', '[]'))
-        if self._environment_variables_dict.get('policy') in ['send_aggregated_alerts', 'cloudability_cost_reports']:
+        if self._environment_variables_dict.get('policy') in ['send_aggregated_alerts', 'cloudability_cost_reports', 'orion_metrics_rollup']:
             self._environment_variables_dict['COMMON_POLICIES'] = True
         # CRO -- Cloud Resource Orch
         self._environment_variables_dict[

--- a/cloud_governance/policy/common_policies/orion_metrics_rollup.py
+++ b/cloud_governance/policy/common_policies/orion_metrics_rollup.py
@@ -15,9 +15,9 @@ class OrionMetricsRollup:
     time series.
     """
 
-    # Read from explicitly, rather than the shared 'es_index' env var: for any
-    # policy in cost_policies (this one included), that var defaults to the
-    # cost-billing index, not the policy index this rollup needs to read from.
+    # Read from explicitly, rather than the shared 'es_index' env var, so the
+    # source index this rollup reads from is unaffected by whatever es_index a
+    # given invocation happens to default to.
     SOURCE_ES_INDEX = 'cloud-governance-policy-es-index'
     # Per-policy resource counts are restricted to these. monitored_policies_savings
     # is NOT restricted to these - see __build_query for why.

--- a/jenkins/tenant/aws/common/run_policies.py
+++ b/jenkins/tenant/aws/common/run_policies.py
@@ -25,7 +25,7 @@ def get_policies(file_type: str = '.py', exclude_policies: list = None):
 exclude_policies = ['cost_explorer', 'optimize_resources_report', 'monthly_report', 'cost_over_usage',
                     'skipped_resources', 'cost_explorer_payer_billings', 'cost_billing_reports',
                     'spot_savings_analysis', 'yearly_savings_report',
-                    'delete_access_key', 'orion_metrics_rollup']
+                    'delete_access_key']
 available_policies = get_policies(exclude_policies=exclude_policies)
 QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ['QUAY_CLOUD_GOVERNANCE_REPOSITORY']
 

--- a/orion-configs/cg-policy-regressions.yaml
+++ b/orion-configs/cg-policy-regressions.yaml
@@ -1,5 +1,5 @@
 # Orion regression-detection config for the metrics produced by
-# cloud_governance/policy/aws/orion_metrics_rollup.py (cloud-governance-orion-metrics-index).
+# cloud_governance/policy/common_policies/orion_metrics_rollup.py (cloud-governance-orion-metrics-index).
 # Invoke once per account, e.g.:
 #   orion --es-server=<opensearch-url> \
 #         --benchmark-index=cloud-governance-orion-metrics-index \

--- a/tests/unittest/cloud_governance/policy/common_policies/test_orion_metrics_rollup.py
+++ b/tests/unittest/cloud_governance/policy/common_policies/test_orion_metrics_rollup.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch, MagicMock
 
-from cloud_governance.policy.aws.orion_metrics_rollup import OrionMetricsRollup
+from cloud_governance.policy.common_policies.orion_metrics_rollup import OrionMetricsRollup
 from tests.unittest.configs import ES_INDEX
 
 
@@ -9,8 +9,8 @@ class TestOrionMetricsRollup:
 
     def setup_method(self):
         """Setup test fixtures"""
-        with patch('cloud_governance.policy.aws.orion_metrics_rollup.environment_variables') as mock_env_vars, \
-             patch('cloud_governance.policy.aws.orion_metrics_rollup.ElasticSearchOperations') as mock_es_ops:
+        with patch('cloud_governance.policy.common_policies.orion_metrics_rollup.environment_variables') as mock_env_vars, \
+             patch('cloud_governance.policy.common_policies.orion_metrics_rollup.ElasticSearchOperations') as mock_es_ops:
             mock_env_vars.environment_variables_dict = {
                 'es_host': 'localhost',
                 'es_port': '9200',
@@ -166,7 +166,7 @@ class TestOrionMetricsRollup:
 
     def test_run_without_es_configured(self):
         """run() should no-op cleanly when ES isn't configured, not raise"""
-        with patch('cloud_governance.policy.aws.orion_metrics_rollup.environment_variables') as mock_env_vars:
+        with patch('cloud_governance.policy.common_policies.orion_metrics_rollup.environment_variables') as mock_env_vars:
             mock_env_vars.environment_variables_dict = {'es_host': '', 'es_port': ''}
             rollup = OrionMetricsRollup()
             result = rollup.run()
@@ -187,7 +187,7 @@ class TestOrionMetricsRollup:
         """A partial date range (only one of start/end set) must not silently backfill - and must warn"""
         self.mock_es_instance.post_query.return_value = {'by_account': {'buckets': []}}
 
-        with patch('cloud_governance.policy.aws.orion_metrics_rollup.logger') as mock_logger:
+        with patch('cloud_governance.policy.common_policies.orion_metrics_rollup.logger') as mock_logger:
             result = self.rollup.run(start_date='2026-01-01')
 
         assert 'date' in result


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
The rollup job only reads from and writes to Elasticsearch and has no per-resource or per-region AWS behaviour, so it belongs with the other cloud-agnostic common policies rather than under policy/aws. Dispatch it through the COMMON_POLICIES path instead of cost_policies, and drop the now-dead auto-discovery exclusion (get_policies only scans policy/aws).
Alters PR https://github.com/redhat-performance/cloud-governance/pull/1017/changes 

## For security reasons, all pull requests need to be approved first before running any automated CI
