### PR TITLE
Fix unreadable timestamps and verbose metric names in Orion Slack alerts

### DIFF
--- a/cloud_governance/common/orion/slack_notifier.py
+++ b/cloud_governance/common/orion/slack_notifier.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime, timezone
 
 import requests
 
@@ -43,6 +44,16 @@ class OrionSlackNotifier:
         return data if isinstance(data, list) else []
 
     @staticmethod
+    def _format_timestamp(ts) -> str:
+        """
+        Orion serializes the timestamp field as Unix epoch seconds in its
+        JSON output, not ISO8601 - convert to a readable date for display.
+        """
+        if isinstance(ts, (int, float)):
+            return datetime.fromtimestamp(ts, tz=timezone.utc).strftime('%Y-%m-%d')
+        return str(ts)
+
+    @staticmethod
     def extract_regressions(data_points: list) -> list:
         """
         Walk the Orion JSON array and pull out change points with their
@@ -63,8 +74,9 @@ class OrionSlackNotifier:
                         'percentage_change': round(pct, 2),
                     })
             if changed_metrics:
+                timestamp = entry.get('timestamp')
                 regressions.append({
-                    'timestamp': entry.get('timestamp', 'unknown'),
+                    'timestamp': OrionSlackNotifier._format_timestamp(timestamp) if timestamp is not None else 'unknown',
                     'account': entry.get('account', entry.get('account.keyword', 'unknown')),
                     'metrics': changed_metrics,
                 })
@@ -85,8 +97,13 @@ class OrionSlackNotifier:
         lines = [f"*Date:* {ts}"]
         for m in regression['metrics']:
             direction = 'increased' if m['percentage_change'] > 0 else 'decreased'
+            # Orion's JSON output keys metrics as "<config_name>_<metric_of_interest>"
+            # (e.g. "zombieClusterResourceCountIncrease_zombie_cluster_resource_count").
+            # Config metric names are plain camelCase with no underscores, so the part
+            # before the first underscore is always just the readable config name.
+            display_name = m['name'].split('_', 1)[0]
             lines.append(
-                f"*{m['name']}*: {direction} by `{abs(m['percentage_change']):.1f}%` (value: {m['value']})"
+                f"*{display_name}*: {direction} by `{abs(m['percentage_change']):.1f}%` (value: {m['value']})"
             )
 
         blocks = []

--- a/tests/unittest/cloud_governance/common/orion/test_slack_notifier.py
+++ b/tests/unittest/cloud_governance/common/orion/test_slack_notifier.py
@@ -11,32 +11,35 @@ from cloud_governance.common.orion.slack_notifier import OrionSlackNotifier
 class TestOrionSlackNotifier:
     """Test suite for OrionSlackNotifier"""
 
+    # Orion's real JSON output keys metrics as "<config_name>_<metric_of_interest>"
+    # and serializes "timestamp" as Unix epoch seconds, not ISO8601 - confirmed
+    # against live output. 1782864000/1784073600/1784505600 = 2026-07-01/15/20.
     SAMPLE_ORION_OUTPUT = [
         {
-            'timestamp': '2026-07-01T00:00:00Z',
+            'timestamp': 1782864000,
             'account': 'PERFSCALE',
             'is_changepoint': False,
             'metrics': {
-                'zombie_cluster_resource_count': {'value': 10, 'percentage_change': 0, 'labels': []},
-                'ec2_stop_count': {'value': 5, 'percentage_change': 0, 'labels': []},
+                'zombieClusterResourceCountIncrease_zombie_cluster_resource_count': {'value': 10, 'percentage_change': 0, 'labels': []},
+                'ec2StopCountIncrease_ec2_stop_count': {'value': 5, 'percentage_change': 0, 'labels': []},
             }
         },
         {
-            'timestamp': '2026-07-15T00:00:00Z',
+            'timestamp': 1784073600,
             'account': 'PERFSCALE',
             'is_changepoint': True,
             'metrics': {
-                'zombie_cluster_resource_count': {'value': 25, 'percentage_change': 150.0, 'labels': []},
-                'ec2_stop_count': {'value': 5, 'percentage_change': 0, 'labels': []},
+                'zombieClusterResourceCountIncrease_zombie_cluster_resource_count': {'value': 25, 'percentage_change': 150.0, 'labels': []},
+                'ec2StopCountIncrease_ec2_stop_count': {'value': 5, 'percentage_change': 0, 'labels': []},
             }
         },
         {
-            'timestamp': '2026-07-20T00:00:00Z',
+            'timestamp': 1784505600,
             'account': 'PERFSCALE',
             'is_changepoint': True,
             'metrics': {
-                'zombie_cluster_resource_count': {'value': 25, 'percentage_change': 0, 'labels': []},
-                'ec2_stop_count': {'value': 2, 'percentage_change': -60.0, 'labels': []},
+                'zombieClusterResourceCountIncrease_zombie_cluster_resource_count': {'value': 25, 'percentage_change': 0, 'labels': []},
+                'ec2StopCountDecrease_ec2_stop_count': {'value': 2, 'percentage_change': -60.0, 'labels': []},
             }
         },
     ]
@@ -79,24 +82,38 @@ class TestOrionSlackNotifier:
         assert len(regressions) == 2
 
         first = regressions[0]
-        assert first['timestamp'] == '2026-07-15T00:00:00Z'
+        assert first['timestamp'] == '2026-07-15'
         assert len(first['metrics']) == 1
-        assert first['metrics'][0]['name'] == 'zombie_cluster_resource_count'
+        assert first['metrics'][0]['name'] == 'zombieClusterResourceCountIncrease_zombie_cluster_resource_count'
         assert first['metrics'][0]['percentage_change'] == 150.0
 
         second = regressions[1]
-        assert second['timestamp'] == '2026-07-20T00:00:00Z'
+        assert second['timestamp'] == '2026-07-20'
         assert len(second['metrics']) == 1
-        assert second['metrics'][0]['name'] == 'ec2_stop_count'
+        assert second['metrics'][0]['name'] == 'ec2StopCountDecrease_ec2_stop_count'
         assert second['metrics'][0]['percentage_change'] == -60.0
+
+    def test_extract_regressions_converts_epoch_timestamp_to_date(self):
+        """Orion serializes timestamp as Unix epoch seconds, not ISO8601 - must be readable"""
+        data = [
+            {
+                'timestamp': 1784073600,
+                'is_changepoint': True,
+                'metrics': {
+                    'someMetricIncrease_some_metric': {'value': 10, 'percentage_change': 50.0, 'labels': []},
+                }
+            }
+        ]
+        regressions = OrionSlackNotifier.extract_regressions(data)
+        assert regressions[0]['timestamp'] == '2026-07-15'
 
     def test_extract_regressions_skips_non_changepoints(self):
         data = [
             {
-                'timestamp': '2026-07-01T00:00:00Z',
+                'timestamp': 1782864000,
                 'is_changepoint': False,
                 'metrics': {
-                    'zombie_cluster_resource_count': {'value': 10, 'percentage_change': 0, 'labels': []},
+                    'zombieClusterResourceCountIncrease_zombie_cluster_resource_count': {'value': 10, 'percentage_change': 0, 'labels': []},
                 }
             }
         ]
@@ -105,10 +122,10 @@ class TestOrionSlackNotifier:
     def test_extract_regressions_skips_changepoint_with_all_zero_changes(self):
         data = [
             {
-                'timestamp': '2026-07-01T00:00:00Z',
+                'timestamp': 1782864000,
                 'is_changepoint': True,
                 'metrics': {
-                    'zombie_cluster_resource_count': {'value': 10, 'percentage_change': 0, 'labels': []},
+                    'zombieClusterResourceCountIncrease_zombie_cluster_resource_count': {'value': 10, 'percentage_change': 0, 'labels': []},
                 }
             }
         ]
@@ -121,10 +138,10 @@ class TestOrionSlackNotifier:
         notifier = OrionSlackNotifier(slack_token='xoxb-test', slack_channel='test-channel')
         regressions = [
             {
-                'timestamp': '2026-07-15T00:00:00Z',
+                'timestamp': '2026-07-15',
                 'account': 'PERFSCALE',
                 'metrics': [
-                    {'name': 'zombie_cluster_resource_count', 'value': 25, 'percentage_change': 150.0},
+                    {'name': 'zombieClusterResourceCountIncrease_zombie_cluster_resource_count', 'value': 25, 'percentage_change': 150.0},
                 ]
             }
         ]
@@ -136,17 +153,21 @@ class TestOrionSlackNotifier:
         assert '1 change point' in blocks[1]['text']['text']
         assert blocks[2]['type'] == 'divider'
         assert blocks[3]['type'] == 'section'
+        assert '2026-07-15' in blocks[3]['text']['text']
         assert 'increased' in blocks[3]['text']['text']
         assert '150.0%' in blocks[3]['text']['text']
+        # Only the readable config name should show, not the raw composite key
+        assert 'zombieClusterResourceCountIncrease' in blocks[3]['text']['text']
+        assert 'zombieClusterResourceCountIncrease_zombie_cluster_resource_count' not in blocks[3]['text']['text']
 
     def test_format_slack_blocks_shows_decrease(self):
         notifier = OrionSlackNotifier(slack_token='xoxb-test', slack_channel='test-channel')
         regressions = [
             {
-                'timestamp': '2026-07-20T00:00:00Z',
+                'timestamp': '2026-07-20',
                 'account': 'PERFSCALE',
                 'metrics': [
-                    {'name': 'ec2_stop_count', 'value': 2, 'percentage_change': -60.0},
+                    {'name': 'ec2StopCountDecrease_ec2_stop_count', 'value': 2, 'percentage_change': -60.0},
                 ]
             }
         ]
@@ -155,6 +176,7 @@ class TestOrionSlackNotifier:
         metric_block = blocks[3]
         assert 'decreased' in metric_block['text']['text']
         assert '60.0%' in metric_block['text']['text']
+        assert 'ec2StopCountDecrease' in metric_block['text']['text']
 
     def test_format_slack_blocks_returns_empty_for_no_regressions(self):
         notifier = OrionSlackNotifier(slack_token='xoxb-test', slack_channel='test-channel')


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Orion's JSON output serializes timestamps as Unix epoch seconds, not ISO8601, and keys each metric as "<config_name>_<metric_of_interest>" rather than the bare field name. Confirmed against a live regression alert. Convert the timestamp to a readable date and display only the config's metric name, which already conveys both the resource and the direction (e.g. zombieClusterResourceCountIncrease).

## For security reasons, all pull requests need to be approved first before running any automated CI
