### PR TITLE
Publish Orion image to quay using GA and wire it into the perf-scale daily job

### DIFF
--- a/.github/workflows/Orion.yml
+++ b/.github/workflows/Orion.yml
@@ -1,0 +1,26 @@
+name: Orion Image
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Docker/orion/**'
+  workflow_dispatch:
+
+concurrency:
+  group: orion-image
+  cancel-in-progress: false
+
+jobs:
+  publish_orion_image:
+    name: publish_orion_image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: ⌛ Build and upload Orion image to 🐋 quay.io
+        run: |
+          sudo docker build -t ${{ secrets.QUAY_PUBLIC_ORION_REPOSITORY }}:latest -f Docker/orion/Dockerfile Docker/orion
+          sudo docker login quay.io -u ${{ secrets.QAUYIO_ROBOT_CLOUD_GOVERNANCE_USER }} -p ${{ secrets.QAUYIO_ROBOT_CLOUD_GOVERNANCE_TOKEN }}
+          sudo docker push ${{ secrets.QUAY_PUBLIC_ORION_REPOSITORY }}:latest
+          echo 'Wait 30 sec till image will be updated in quay.io'
+          sleep 30

--- a/.github/workflows/Orion.yml
+++ b/.github/workflows/Orion.yml
@@ -19,8 +19,11 @@ jobs:
       - uses: actions/checkout@v6
       - name: ⌛ Build and upload Orion image to 🐋 quay.io
         run: |
-          sudo docker build -t ${{ secrets.QUAY_PUBLIC_ORION_REPOSITORY }}:latest -f Docker/orion/Dockerfile Docker/orion
+          # Reuses the existing cloud-governance repository secret rather than a
+          # separate one, so the two image paths can never drift apart.
+          ORION_REPOSITORY="${{ secrets.QUAY_PUBLIC_CLOUD_GOVERNANCE_REPOSITORY }}-orion"
+          sudo docker build -t "$ORION_REPOSITORY:latest" -f Docker/orion/Dockerfile Docker/orion
           sudo docker login quay.io -u ${{ secrets.QAUYIO_ROBOT_CLOUD_GOVERNANCE_USER }} -p ${{ secrets.QAUYIO_ROBOT_CLOUD_GOVERNANCE_TOKEN }}
-          sudo docker push ${{ secrets.QUAY_PUBLIC_ORION_REPOSITORY }}:latest
+          sudo docker push "$ORION_REPOSITORY:latest"
           echo 'Wait 30 sec till image will be updated in quay.io'
           sleep 30

--- a/.github/workflows/Orion.yml
+++ b/.github/workflows/Orion.yml
@@ -18,12 +18,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: ⌛ Build and upload Orion image to 🐋 quay.io
+        env:
+          QUAY_USER: ${{ secrets.QAUYIO_ROBOT_CLOUD_GOVERNANCE_USER }}
+          QUAY_TOKEN: ${{ secrets.QAUYIO_ROBOT_CLOUD_GOVERNANCE_TOKEN }}
+          QUAY_REPOSITORY: ${{ secrets.QUAY_PUBLIC_CLOUD_GOVERNANCE_REPOSITORY }}
         run: |
           # Reuses the existing cloud-governance repository secret rather than a
           # separate one, so the two image paths can never drift apart.
-          ORION_REPOSITORY="${{ secrets.QUAY_PUBLIC_CLOUD_GOVERNANCE_REPOSITORY }}-orion"
+          ORION_REPOSITORY="${QUAY_REPOSITORY}-orion"
           sudo docker build -t "$ORION_REPOSITORY:latest" -f Docker/orion/Dockerfile Docker/orion
-          sudo docker login quay.io -u ${{ secrets.QAUYIO_ROBOT_CLOUD_GOVERNANCE_USER }} -p ${{ secrets.QAUYIO_ROBOT_CLOUD_GOVERNANCE_TOKEN }}
+          # Pipe the token via stdin rather than -p so it is never visible as a
+          # process argument.
+          printf '%s' "$QUAY_TOKEN" | sudo docker login quay.io -u "$QUAY_USER" --password-stdin
           sudo docker push "$ORION_REPOSITORY:latest"
           echo 'Wait 30 sec till image will be updated in quay.io'
           sleep 30

--- a/jenkins/clouds/aws/daily/policies/Jenkinsfile
+++ b/jenkins/clouds/aws/daily/policies/Jenkinsfile
@@ -12,6 +12,12 @@ pipeline {
     }
     environment {
         QUAY_CLOUD_GOVERNANCE_REPOSITORY = credentials('QUAY_CLOUD_GOVERNANCE_REPOSITORY')
+        // Orion regression detection: these 3 credentials must exist in Jenkins
+        // before this Jenkinsfile is deployed, otherwise the pipeline fails to
+        // start for every account (credentials() errors on an unknown ID).
+        QUAY_ORION_REPOSITORY = credentials('QUAY_ORION_REPOSITORY')
+        SLACK_API_TOKEN = credentials('cloud-governance-slack-api-token')
+        SLACK_CHANNEL_NAME = credentials('cloud-governance-slack-channel-name')
         POLICIES_IN_ACTION = '["instance_idle", "ec2_stop", "unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "delete_access_key", "zombie_cluster_resource"]'
         AWS_IAM_USER_SPREADSHEET_ID = credentials('cloud-governance-aws-iam-user-spreadsheet-id')
         GOOGLE_APPLICATION_CREDENTIALS = credentials('cloud-governance-google-application-credentials')

--- a/jenkins/clouds/aws/daily/policies/Jenkinsfile
+++ b/jenkins/clouds/aws/daily/policies/Jenkinsfile
@@ -12,10 +12,11 @@ pipeline {
     }
     environment {
         QUAY_CLOUD_GOVERNANCE_REPOSITORY = credentials('QUAY_CLOUD_GOVERNANCE_REPOSITORY')
-        // Orion regression detection: these 3 credentials must exist in Jenkins
+        // Orion regression detection: these 2 credentials must exist in Jenkins
         // before this Jenkinsfile is deployed, otherwise the pipeline fails to
-        // start for every account (credentials() errors on an unknown ID).
-        QUAY_ORION_REPOSITORY = credentials('QUAY_ORION_REPOSITORY')
+        // start for every account (credentials() errors on an unknown ID). The
+        // Orion image repository is derived from QUAY_CLOUD_GOVERNANCE_REPOSITORY
+        // above, not a separate credential.
         SLACK_API_TOKEN = credentials('cloud-governance-slack-api-token')
         SLACK_CHANNEL_NAME = credentials('cloud-governance-slack-channel-name')
         POLICIES_IN_ACTION = '["instance_idle", "ec2_stop", "unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "delete_access_key", "zombie_cluster_resource"]'

--- a/jenkins/clouds/aws/daily/policies/Jenkinsfile
+++ b/jenkins/clouds/aws/daily/policies/Jenkinsfile
@@ -12,11 +12,6 @@ pipeline {
     }
     environment {
         QUAY_CLOUD_GOVERNANCE_REPOSITORY = credentials('QUAY_CLOUD_GOVERNANCE_REPOSITORY')
-        // Orion regression detection: these 2 credentials must exist in Jenkins
-        // before this Jenkinsfile is deployed, otherwise the pipeline fails to
-        // start for every account (credentials() errors on an unknown ID). The
-        // Orion image repository is derived from QUAY_CLOUD_GOVERNANCE_REPOSITORY
-        // above, not a separate credential.
         SLACK_API_TOKEN = credentials('cloud-governance-slack-api-token')
         SLACK_CHANNEL_NAME = credentials('cloud-governance-slack-channel-name')
         POLICIES_IN_ACTION = '["instance_idle", "ec2_stop", "unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "delete_access_key", "zombie_cluster_resource"]'

--- a/jenkins/clouds/aws/daily/policies/run_policies.py
+++ b/jenkins/clouds/aws/daily/policies/run_policies.py
@@ -22,9 +22,10 @@ SPREADSHEET_ID = os.environ['AWS_IAM_USER_SPREADSHEET_ID']
 GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
 ADMIN_MAIL_LIST = os.environ.get('ADMIN_MAIL_LIST', '')
 QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ['QUAY_CLOUD_GOVERNANCE_REPOSITORY']
+# Derived, not a separate credential, so the two image paths can never drift apart.
+QUAY_ORION_REPOSITORY = f'{QUAY_CLOUD_GOVERNANCE_REPOSITORY}-orion'
 # Orion regression detection is optional: skips quietly (does not fail the job)
-# if any of these three are not configured as Jenkins credentials.
-QUAY_ORION_REPOSITORY = os.environ.get('QUAY_ORION_REPOSITORY', '')
+# if these are not configured as Jenkins credentials.
 SLACK_API_TOKEN = os.environ.get('SLACK_API_TOKEN', '')
 SLACK_CHANNEL_NAME = os.environ.get('SLACK_CHANNEL_NAME', '')
 
@@ -158,7 +159,7 @@ run_cmd(
 # change-point analysis against it, and post any regressions to Slack.
 # Must run after all of this account's policies above have finished writing
 # to cloud-governance-policy-es-index, since the rollup step reads from it.
-if QUAY_ORION_REPOSITORY and SLACK_API_TOKEN and SLACK_CHANNEL_NAME:
+if SLACK_API_TOKEN and SLACK_CHANNEL_NAME:
     REPO_ROOT = os.path.dirname(
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))))
     ORION_CONFIG_PATH = os.path.join(REPO_ROOT, 'orion-configs', 'cg-policy-regressions.yaml')
@@ -186,4 +187,4 @@ if QUAY_ORION_REPOSITORY and SLACK_API_TOKEN and SLACK_CHANNEL_NAME:
 
     run_cmd(f'rm -f "{orion_output_file}"')
 else:
-    run_cmd("echo Skipping Orion regression detection - QUAY_ORION_REPOSITORY/SLACK_API_TOKEN/SLACK_CHANNEL_NAME not configured")
+    run_cmd("echo Skipping Orion regression detection - SLACK_API_TOKEN/SLACK_CHANNEL_NAME not configured")

--- a/jenkins/clouds/aws/daily/policies/run_policies.py
+++ b/jenkins/clouds/aws/daily/policies/run_policies.py
@@ -22,10 +22,7 @@ SPREADSHEET_ID = os.environ['AWS_IAM_USER_SPREADSHEET_ID']
 GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
 ADMIN_MAIL_LIST = os.environ.get('ADMIN_MAIL_LIST', '')
 QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ['QUAY_CLOUD_GOVERNANCE_REPOSITORY']
-# Derived, not a separate credential, so the two image paths can never drift apart.
 QUAY_ORION_REPOSITORY = f'{QUAY_CLOUD_GOVERNANCE_REPOSITORY}-orion'
-# Orion regression detection is optional: skips quietly (does not fail the job)
-# if these are not configured as Jenkins credentials.
 SLACK_API_TOKEN = os.environ.get('SLACK_API_TOKEN', '')
 SLACK_CHANNEL_NAME = os.environ.get('SLACK_CHANNEL_NAME', '')
 
@@ -163,8 +160,6 @@ if SLACK_API_TOKEN and SLACK_CHANNEL_NAME:
     REPO_ROOT = os.path.dirname(
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))))
     ORION_CONFIG_PATH = os.path.join(REPO_ROOT, 'orion-configs', 'cg-policy-regressions.yaml')
-    # Must match the 'name:' field of the test in ORION_CONFIG_PATH: Orion's
-    # JSON formatter appends "_<test_name>" to whatever --save-output-path is given.
     ORION_TEST_NAME = 'cg-policy-regressions'
 
     run_cmd("echo Running Orion metrics rollup")
@@ -176,15 +171,23 @@ if SLACK_API_TOKEN and SLACK_CHANNEL_NAME:
     es_server = f'{es_scheme}://{es_auth}{ES_HOST}:{ES_PORT}'
     orion_output_base = f'/tmp/orion-output-{account_name}.json'
     orion_output_file = f'/tmp/orion-output-{account_name}_{ORION_TEST_NAME}.json'
+    # Orion also always writes a CSV of the underlying data alongside the JSON
+    # output; without an explicit path every account would overwrite the same
+    # file. We never read this CSV, so it's just given an account-specific
+    # name and cleaned up with the JSON output below. Orion builds the actual
+    # written filename from the *first* dot in the given path (not the
+    # extension), so the actual file is "<path-before-first-dot>-<test_name>.csv".
+    orion_data_base = f'/tmp/orion-data-{account_name}.csv'
+    orion_data_file = f'/tmp/orion-data-{account_name}-{ORION_TEST_NAME}.csv'
 
     run_cmd("echo Running Orion regression analysis")
     run_cmd(
-        f"""podman run --rm --name orion --net="host" -v "{ORION_CONFIG_PATH}":"{ORION_CONFIG_PATH}" -v /tmp:/tmp {QUAY_ORION_REPOSITORY} --es-server="{es_server}" --benchmark-index="cloud-governance-orion-metrics-index" --metadata-index="cloud-governance-orion-metrics-index" --hunter-analyze --input-vars='{{"account": "{account_name.upper()}"}}' --config "{ORION_CONFIG_PATH}" --output-format json --save-output-path "{orion_output_base}" """)
+        f"""podman run --rm --name orion --net="host" -v "{ORION_CONFIG_PATH}":"{ORION_CONFIG_PATH}" -v /tmp:/tmp {QUAY_ORION_REPOSITORY} --es-server="{es_server}" --benchmark-index="cloud-governance-orion-metrics-index" --metadata-index="cloud-governance-orion-metrics-index" --hunter-analyze --input-vars='{{"account": "{account_name.upper()}"}}' --config "{ORION_CONFIG_PATH}" --output-format json --save-output-path "{orion_output_base}" --save-data-path "{orion_data_base}" """)
 
     run_cmd("echo Running Orion Slack alert handler")
     run_cmd(
         f"""podman run --rm --name cloud-governance --net="host" -v /tmp:/tmp -e account="{account_name}" -e policy="orion_alert_handler" -e ORION_OUTPUT_FILE="{orion_output_file}" -e SLACK_API_TOKEN="{SLACK_API_TOKEN}" -e SLACK_CHANNEL_NAME="{SLACK_CHANNEL_NAME}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
 
-    run_cmd(f'rm -f "{orion_output_file}"')
+    run_cmd(f'rm -f "{orion_output_file}" "{orion_data_file}"')
 else:
     run_cmd("echo Skipping Orion regression detection - SLACK_API_TOKEN/SLACK_CHANNEL_NAME not configured")

--- a/jenkins/clouds/aws/daily/policies/run_policies.py
+++ b/jenkins/clouds/aws/daily/policies/run_policies.py
@@ -22,6 +22,11 @@ SPREADSHEET_ID = os.environ['AWS_IAM_USER_SPREADSHEET_ID']
 GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
 ADMIN_MAIL_LIST = os.environ.get('ADMIN_MAIL_LIST', '')
 QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ['QUAY_CLOUD_GOVERNANCE_REPOSITORY']
+# Orion regression detection is optional: skips quietly (does not fail the job)
+# if any of these three are not configured as Jenkins credentials.
+QUAY_ORION_REPOSITORY = os.environ.get('QUAY_ORION_REPOSITORY', '')
+SLACK_API_TOKEN = os.environ.get('SLACK_API_TOKEN', '')
+SLACK_CHANNEL_NAME = os.environ.get('SLACK_CHANNEL_NAME', '')
 
 
 def get_policies(file_type: str = '.py', exclude_policies: list = None):
@@ -148,3 +153,37 @@ run_cmd(
 run_cmd("echo Run Aggregated Email Alert")
 run_cmd(
     f"""podman run --rm --name cloud-governance --net="host" -e account="{account_name}" -e policy="send_aggregated_alerts" -e AWS_ACCESS_KEY_ID="{access_key}" -e AWS_SECRET_ACCESS_KEY="{secret_key}" -e LDAP_HOST_NAME="{LDAP_HOST_NAME}"  -e log_level="INFO" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}" -e es_user="{ES_USER}" -e es_password="{ES_PASSWORD}" -e ADMIN_MAIL_LIST="{ADMIN_MAIL_LIST}" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+
+# Orion regression detection: roll up today's policy data, run Orion's
+# change-point analysis against it, and post any regressions to Slack.
+# Must run after all of this account's policies above have finished writing
+# to cloud-governance-policy-es-index, since the rollup step reads from it.
+if QUAY_ORION_REPOSITORY and SLACK_API_TOKEN and SLACK_CHANNEL_NAME:
+    REPO_ROOT = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))))
+    ORION_CONFIG_PATH = os.path.join(REPO_ROOT, 'orion-configs', 'cg-policy-regressions.yaml')
+    # Must match the 'name:' field of the test in ORION_CONFIG_PATH: Orion's
+    # JSON formatter appends "_<test_name>" to whatever --save-output-path is given.
+    ORION_TEST_NAME = 'cg-policy-regressions'
+
+    run_cmd("echo Running Orion metrics rollup")
+    run_cmd(
+        f"""podman run --rm --name cloud-governance --net="host" -e account="{account_name}" -e policy="orion_metrics_rollup" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}" -e es_user="{ES_USER}" -e es_password="{ES_PASSWORD}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+
+    es_scheme = 'https' if str(ES_PORT) == '443' else 'http'
+    es_auth = f'{ES_USER}:{ES_PASSWORD}@' if ES_USER else ''
+    es_server = f'{es_scheme}://{es_auth}{ES_HOST}:{ES_PORT}'
+    orion_output_base = f'/tmp/orion-output-{account_name}.json'
+    orion_output_file = f'/tmp/orion-output-{account_name}_{ORION_TEST_NAME}.json'
+
+    run_cmd("echo Running Orion regression analysis")
+    run_cmd(
+        f"""podman run --rm --name orion --net="host" -v "{ORION_CONFIG_PATH}":"{ORION_CONFIG_PATH}" -v /tmp:/tmp {QUAY_ORION_REPOSITORY} --es-server="{es_server}" --benchmark-index="cloud-governance-orion-metrics-index" --metadata-index="cloud-governance-orion-metrics-index" --hunter-analyze --input-vars='{{"account": "{account_name.upper()}"}}' --config "{ORION_CONFIG_PATH}" --output-format json --save-output-path "{orion_output_base}" """)
+
+    run_cmd("echo Running Orion Slack alert handler")
+    run_cmd(
+        f"""podman run --rm --name cloud-governance --net="host" -v /tmp:/tmp -e account="{account_name}" -e policy="orion_alert_handler" -e ORION_OUTPUT_FILE="{orion_output_file}" -e SLACK_API_TOKEN="{SLACK_API_TOKEN}" -e SLACK_CHANNEL_NAME="{SLACK_CHANNEL_NAME}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+
+    run_cmd(f'rm -f "{orion_output_file}"')
+else:
+    run_cmd("echo Skipping Orion regression detection - QUAY_ORION_REPOSITORY/SLACK_API_TOKEN/SLACK_CHANNEL_NAME not configured")

--- a/jenkins/clouds/aws/daily/policies/run_policies.py
+++ b/jenkins/clouds/aws/daily/policies/run_policies.py
@@ -63,10 +63,10 @@ def run_cmd(cmd: str):
     This method runs the shell command
     :param cmd:
     :type cmd:
-    :return:
-    :rtype:
+    :return: the raw os.system status (0 on success)
+    :rtype: int
     """
-    os.system(cmd)
+    return os.system(cmd)
 
 
 def get_container_cmd(env_dict: dict):
@@ -162,10 +162,6 @@ if SLACK_API_TOKEN and SLACK_CHANNEL_NAME:
     ORION_CONFIG_PATH = os.path.join(REPO_ROOT, 'orion-configs', 'cg-policy-regressions.yaml')
     ORION_TEST_NAME = 'cg-policy-regressions'
 
-    run_cmd("echo Running Orion metrics rollup")
-    run_cmd(
-        f"""podman run --rm --name cloud-governance --net="host" -e account="{account_name}" -e policy="orion_metrics_rollup" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}" -e es_user="{ES_USER}" -e es_password="{ES_PASSWORD}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
-
     es_scheme = 'https' if str(ES_PORT) == '443' else 'http'
     es_auth = f'{ES_USER}:{ES_PASSWORD}@' if ES_USER else ''
     es_server = f'{es_scheme}://{es_auth}{ES_HOST}:{ES_PORT}'
@@ -180,14 +176,32 @@ if SLACK_API_TOKEN and SLACK_CHANNEL_NAME:
     orion_data_base = f'/tmp/orion-data-{account_name}.csv'
     orion_data_file = f'/tmp/orion-data-{account_name}-{ORION_TEST_NAME}.csv'
 
-    run_cmd("echo Running Orion regression analysis")
-    run_cmd(
-        f"""podman run --rm --name orion --net="host" -v "{ORION_CONFIG_PATH}":"{ORION_CONFIG_PATH}" -v /tmp:/tmp {QUAY_ORION_REPOSITORY} --es-server="{es_server}" --benchmark-index="cloud-governance-orion-metrics-index" --metadata-index="cloud-governance-orion-metrics-index" --hunter-analyze --input-vars='{{"account": "{account_name.upper()}"}}' --config "{ORION_CONFIG_PATH}" --output-format json --save-output-path "{orion_output_base}" --save-data-path "{orion_data_base}" """)
-
-    run_cmd("echo Running Orion Slack alert handler")
-    run_cmd(
-        f"""podman run --rm --name cloud-governance --net="host" -v /tmp:/tmp -e account="{account_name}" -e policy="orion_alert_handler" -e ORION_OUTPUT_FILE="{orion_output_file}" -e SLACK_API_TOKEN="{SLACK_API_TOKEN}" -e SLACK_CHANNEL_NAME="{SLACK_CHANNEL_NAME}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
-
+    # Clear any output left over from an earlier run so a failed analysis this
+    # run cannot leave a stale file for the alert handler to re-read and re-alert.
     run_cmd(f'rm -f "{orion_output_file}" "{orion_data_file}"')
+
+    run_cmd("echo Running Orion metrics rollup")
+    rollup_status = run_cmd(
+        f"""podman run --rm --name cloud-governance --net="host" -e account="{account_name}" -e policy="orion_metrics_rollup" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}" -e es_user="{ES_USER}" -e es_password="{ES_PASSWORD}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+
+    if rollup_status != 0:
+        run_cmd("echo Skipping Orion analysis and alert - metrics rollup failed")
+    else:
+        try:
+            run_cmd("echo Running Orion regression analysis")
+            # Orion exits non-zero (2) when it detects regressions, so its exit
+            # status cannot gate the next step; the presence of the output file,
+            # which is written only when analysis completes, is used instead.
+            run_cmd(
+                f"""podman run --rm --name orion --net="host" -v "{ORION_CONFIG_PATH}":"{ORION_CONFIG_PATH}" -v /tmp:/tmp {QUAY_ORION_REPOSITORY} --es-server="{es_server}" --benchmark-index="cloud-governance-orion-metrics-index" --metadata-index="cloud-governance-orion-metrics-index" --hunter-analyze --input-vars='{{"account": "{account_name.upper()}"}}' --config "{ORION_CONFIG_PATH}" --output-format json --save-output-path "{orion_output_base}" --save-data-path "{orion_data_base}" """)
+
+            if os.path.exists(orion_output_file):
+                run_cmd("echo Running Orion Slack alert handler")
+                run_cmd(
+                    f"""podman run --rm --name cloud-governance --net="host" -v /tmp:/tmp -e account="{account_name}" -e policy="orion_alert_handler" -e ORION_OUTPUT_FILE="{orion_output_file}" -e SLACK_API_TOKEN="{SLACK_API_TOKEN}" -e SLACK_CHANNEL_NAME="{SLACK_CHANNEL_NAME}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+            else:
+                run_cmd("echo Skipping Orion alert - analysis produced no output")
+        finally:
+            run_cmd(f'rm -f "{orion_output_file}" "{orion_data_file}"')
 else:
     run_cmd("echo Skipping Orion regression detection - SLACK_API_TOKEN/SLACK_CHANNEL_NAME not configured")


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
1. Created a Github Actions workflow file to update Orion image to Quay. It can be triggered manually or when a change to Docker/orion/* occurs. 
2. Wired the Orion metrics rollup job, alert handler, slack notifier job into the Jenkins daily policies run. 

## Testing Done: 
1. Tested with local Dockerfile build
2. manual end-to-end dry run - rollup, analysis, and alert-handler all confirmed working against real production ES + real Slack.

## Next Steps post merging the PR:
1. Test the Github actions workflow, and the quay upload
2. Create the slack credentials and verify whether the orion policies work as expected in the next jenkins policies run.


## For security reasons, all pull requests need to be approved first before running any automated CI
