### PR TITLE
Make Orion Slack credentials optional in the daily Jenkins job

### DIFF
--- a/jenkins/clouds/aws/daily/policies/Jenkinsfile
+++ b/jenkins/clouds/aws/daily/policies/Jenkinsfile
@@ -64,7 +64,9 @@ pipeline {
                         }
                         orionSlackBindings = [string(credentialsId: 'cloud-governance-slack-api-token', variable: 'SLACK_API_TOKEN'),
                                               string(credentialsId: 'cloud-governance-slack-channel-name', variable: 'SLACK_CHANNEL_NAME')]
-                    } catch (Exception e) {
+                    } catch (org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException e) {
+                        // Only a genuinely absent credential disables Orion; transient
+                        // plugin errors and build interruptions propagate and fail the job.
                         echo 'Orion Slack credentials not configured - Orion regression alerts disabled for this run'
                     }
                     for (account in accounts_list.keySet()) {

--- a/jenkins/clouds/aws/daily/policies/Jenkinsfile
+++ b/jenkins/clouds/aws/daily/policies/Jenkinsfile
@@ -12,8 +12,10 @@ pipeline {
     }
     environment {
         QUAY_CLOUD_GOVERNANCE_REPOSITORY = credentials('QUAY_CLOUD_GOVERNANCE_REPOSITORY')
-        SLACK_API_TOKEN = credentials('cloud-governance-slack-api-token')
-        SLACK_CHANNEL_NAME = credentials('cloud-governance-slack-channel-name')
+        // Orion Slack credentials are intentionally NOT bound here: credentials()
+        // in an environment block fails the whole pipeline if the id is missing.
+        // They are bound optionally in the 'Run Daily Policies' stage instead, so
+        // that a missing Orion credential only disables Orion, not the daily job.
         POLICIES_IN_ACTION = '["instance_idle", "ec2_stop", "unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "delete_access_key", "zombie_cluster_resource"]'
         AWS_IAM_USER_SPREADSHEET_ID = credentials('cloud-governance-aws-iam-user-spreadsheet-id')
         GOOGLE_APPLICATION_CREDENTIALS = credentials('cloud-governance-google-application-credentials')
@@ -51,11 +53,25 @@ pipeline {
         stage('Run Daily Policies') {
             steps {
                  script {
+                    // Probe the optional Orion Slack credentials once. If they are
+                    // not configured, run_policies.py simply skips Orion; a missing
+                    // credential must not fail the whole daily job.
+                    def orionSlackBindings = []
+                    try {
+                        withCredentials([string(credentialsId: 'cloud-governance-slack-api-token', variable: 'SLACK_API_TOKEN'),
+                                         string(credentialsId: 'cloud-governance-slack-channel-name', variable: 'SLACK_CHANNEL_NAME')]) {
+                            // no-op: only checking that the credentials resolve
+                        }
+                        orionSlackBindings = [string(credentialsId: 'cloud-governance-slack-api-token', variable: 'SLACK_API_TOKEN'),
+                                              string(credentialsId: 'cloud-governance-slack-channel-name', variable: 'SLACK_CHANNEL_NAME')]
+                    } catch (Exception e) {
+                        echo 'Orion Slack credentials not configured - Orion regression alerts disabled for this run'
+                    }
                     for (account in accounts_list.keySet()) {
                         echo "Running for account ${account.toUpperCase()}"
                         withCredentials([string(credentialsId: "${account}-aws-access-key-id", variable: 'access_key'),
                                         string(credentialsId: "${account}-aws-secret-key-id", variable: 'secret_key'),
-                                        string(credentialsId: "${account}-s3-bucket", variable: 's3_bucket')]) {
+                                        string(credentialsId: "${account}-s3-bucket", variable: 's3_bucket')] + orionSlackBindings) {
                             env.account_name = "${account}"
                             env.ADMIN_MAIL_LIST = "${accounts_list[account]}"
                             sh 'python3 jenkins/clouds/aws/daily/policies/run_policies.py'


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Binding the two Orion Slack credentials via credentials() in the environment block failed the entire daily pipeline when the ids were not yet configured, before run_policies.py's skip logic could run. Bind them optionally in the Run Daily Policies stage instead: probe once, and only add them to the per-account withCredentials call if they resolve. A missing Orion credential now just disables Orion for the run rather than breaking the whole job.

## For security reasons, all pull requests need to be approved first before running any automated CI
