### PR TITLE
Enable zombie_cluster_resource in dry_run=no for ecoeng_01

### DIFF
--- a/jenkins/tenant/aws/ecoeng_01/PolicyJenkinsfileDaily
+++ b/jenkins/tenant/aws/ecoeng_01/PolicyJenkinsfileDaily
@@ -46,7 +46,7 @@ pipeline {
         // Find the all available policies: https://github.com/redhat-performance/cloud-governance/tree/main/cloud_governance/policy
         // By default, all policies are running in dry_run="yes" mode and the whole list can be found in run_policies.py
         // POLICIES_IN_ACTION: Policies that run in the dry_run="no" mode
-        POLICIES_IN_ACTION = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles"]'
+        POLICIES_IN_ACTION = '["unattached_volume", "ip_unattached", "zombie_snapshots", "unused_nat_gateway", "s3_inactive", "empty_roles", "zombie_cluster_resource"]'
         SKIP_POLICIES_ALERT = '["unused_access_key"]'
     }
     stages {


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [ ] enhancement
- [ ] documentation
- [x] dependencies

## Description
Add zombie_cluster_resource to POLICIES_IN_ACTION so it runs in dry_run=no mode for the ecoeng_01 tenant accounts, matching the existing cleanup policies already in action.

## For security reasons, all pull requests need to be approved first before running any automated CI
