### PR TITLE
Fix zombie cluster global-resource counter inflation and IAM role deletion 

### DIFF
--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/delete_iam_resources.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/delete_iam_resources.py
@@ -48,11 +48,14 @@ class DeleteIAMResources:
             if policy_names.get('PolicyNames'):
                 for policy in policy_names.get('PolicyNames'):
                     self.iam_client.delete_role_policy(RoleName=resource_id, PolicyName=policy)
-            instance_policies = self.iam_client.list_instance_profiles_for_role(RoleName=resource_id)
-            if instance_policies['InstanceProfiles']:
-                self.iam_client.remove_role_from_instance_profile(RoleName=resource_id,
-                                                                  InstanceProfileName=resource_id.replace('role',
-                                                                                                          'profile'))
+            # Use the actual instance profile name(s) returned by the API. The profile name does not
+            # reliably follow the role name (installer convention is role '<name>-worker-role' with
+            # instance profile '<name>-worker'), so deriving it by string replacement fails.
+            instance_profiles = self.iam_client.list_instance_profiles_for_role(
+                RoleName=resource_id).get('InstanceProfiles', [])
+            for instance_profile in instance_profiles:
+                self.iam_client.remove_role_from_instance_profile(
+                    RoleName=resource_id, InstanceProfileName=instance_profile['InstanceProfileName'])
             self.iam_client.delete_role(RoleName=resource_id)
             logger.info(f'delete_role: {resource_id}')
         except Exception as err:

--- a/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
+++ b/cloud_governance/policy/policy_operations/aws/zombie_cluster/run_zombie_cluster_resources.py
@@ -4,12 +4,18 @@ import typeguard
 
 from cloud_governance.common.clouds.aws.utils.common_methods import get_tag_value_from_tags
 from cloud_governance.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
+from cloud_governance.common.utils.configs import AWS_DEFAULT_GLOBAL_REGION
 from cloud_governance.main.environment_variables import environment_variables
 from cloud_governance.policy.policy_operations.aws.zombie_cluster.zombie_cluster_common_methods import \
     ZombieClusterCommonMethods
 from cloud_governance.common.logger.init_logger import logger
 from cloud_governance.common.logger.logger_time_stamp import logger_time_stamp
 from cloud_governance.policy.aws.zombie_cluster_resource import ZombieClusterResources
+
+# Global (non-regional) AWS resources. They appear in every region's scan, so they must only be
+# processed in a single region (AWS_DEFAULT_GLOBAL_REGION); otherwise the ClusterDeleteDays day
+# counter is incremented once per region per day (~17x too fast), causing premature deletion.
+GLOBAL_ZOMBIE_CLUSTER_RESOURCES = ('zombie_cluster_role', 'zombie_cluster_user', 'zombie_cluster_s3_bucket')
 
 
 @typeguard.typechecked
@@ -120,6 +126,10 @@ def zombie_cluster_resource(delete: bool = False, region: str = 'us-east-2', res
     zombie_cluster_resources_ids = {}
     zombie_cluster_resources_data = {}
     for func in func_resource_list:
+        # Global resources are only processed in AWS_DEFAULT_GLOBAL_REGION so their day counter
+        # advances once per day instead of once per region per day.
+        if region != AWS_DEFAULT_GLOBAL_REGION and func.__name__ in GLOBAL_ZOMBIE_CLUSTER_RESOURCES:
+            continue
         resource_data, cluster_left_out_days = func()
         if resource_data:
             notify_data, delete_data, cluster_data = zombie_cluster_common_methods.collect_notify_cluster_data(
@@ -153,11 +163,10 @@ def zombie_cluster_resource(delete: bool = False, region: str = 'us-east-2', res
         account = environment_variables_dict.get('account', '')
         if zombie_cluster_result:
             regional_zombie_cluster_ids = []
-            global_zombie_cluster_resources = ['zombie_cluster_role', 'zombie_cluster_s3_bucket']
             for zombie_cluster_id, resources_data in zombie_cluster_resources_data.items():
-                if (len(resources_data) > 0 and resources_data[0] in global_zombie_cluster_resources) \
-                        or (len(resources_data) > 1 and resources_data[1] in global_zombie_cluster_resources):
-                    if region == 'us-east-1':
+                if (len(resources_data) > 0 and resources_data[0] in GLOBAL_ZOMBIE_CLUSTER_RESOURCES) \
+                        or (len(resources_data) > 1 and resources_data[1] in GLOBAL_ZOMBIE_CLUSTER_RESOURCES):
+                    if region == AWS_DEFAULT_GLOBAL_REGION:
                         regional_zombie_cluster_ids.append(zombie_cluster_id)
                     else:
                         continue

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_run_zombie_cluster_resources.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_run_zombie_cluster_resources.py
@@ -1,0 +1,54 @@
+import json
+from unittest.mock import patch
+
+import boto3
+from moto import mock_aws
+
+from cloud_governance.main.environment_variables import environment_variables
+from cloud_governance.policy.policy_operations.aws.zombie_cluster import run_zombie_cluster_resources
+from cloud_governance.policy.policy_operations.aws.zombie_cluster.run_zombie_cluster_resources import (
+    zombie_cluster_resource, GLOBAL_ZOMBIE_CLUSTER_RESOURCES)
+
+CLUSTER_PREFIX = ["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"]
+GLOBAL_REGION = 'us-east-1'
+NON_GLOBAL_REGION = 'us-west-2'
+
+
+def _create_zombie_cluster_role():
+    """Create an IAM worker role (global resource) tagged to a cluster that has no instances."""
+    iam = boto3.client('iam')
+    assume = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"},
+                       "Action": "sts:AssumeRole"}]
+    })
+    iam.create_role(RoleName='unittest-guard-worker-role', AssumeRolePolicyDocument=assume,
+                    Tags=[{'Key': 'kubernetes.io/cluster/unittest-guard-cluster', 'Value': 'owned'}])
+
+
+def _run(region):
+    environment_variables.environment_variables_dict['CLUSTER_PREFIX'] = CLUSTER_PREFIX
+    with patch.object(run_zombie_cluster_resources, 'ElasticSearchOperations') as es:
+        es.return_value.check_elastic_search_connection.return_value = False
+        return zombie_cluster_resource(delete=False, region=region)
+
+
+def test_global_resources_constant_contains_role_and_s3():
+    assert 'zombie_cluster_role' in GLOBAL_ZOMBIE_CLUSTER_RESOURCES
+    assert 'zombie_cluster_s3_bucket' in GLOBAL_ZOMBIE_CLUSTER_RESOURCES
+
+
+@mock_aws
+def test_global_resource_skipped_in_non_global_region():
+    """A zombie IAM role must NOT be scanned/counted in a non-global region (prevents 17x inflation)."""
+    _create_zombie_cluster_role()
+    result = _run(NON_GLOBAL_REGION)
+    assert 'zombie_cluster_role' not in result
+
+
+@mock_aws
+def test_global_resource_processed_in_global_region():
+    """The same zombie IAM role IS scanned once, in the global region."""
+    _create_zombie_cluster_role()
+    result = _run(GLOBAL_REGION)
+    assert 'zombie_cluster_role' in result

--- a/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_iam_cluster_delete_resource.py
+++ b/tests/unittest/cloud_governance/aws/zombie_cluster/test_zombie_iam_cluster_delete_resource.py
@@ -136,6 +136,38 @@ def test_not_delete_iam_cluster_role():
 
 
 @mock_aws
+def test_delete_iam_role_with_installer_instance_profile_naming():
+    """
+    Reproduces the real installer naming convention: role '<name>-worker-role' with an instance
+    profile named '<name>-worker' (NOT '<name>-worker-profile'). The buggy code derived the profile
+    name via resource_id.replace('role', 'profile') and failed with NoSuchEntity, leaving the role
+    undeleted. The role must be deleted when using the actual profile name from the API.
+    """
+    iam_resource = boto3.client('iam')
+    assume_role_policy_document = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"},
+                       "Action": "sts:AssumeRole"}]
+    })
+    tags = [{'Key': 'kubernetes.io/cluster/unittest-real-cluster', 'Value': 'owned'}]
+    iam_resource.create_role(RoleName='unittest-real-worker-role',
+                             AssumeRolePolicyDocument=assume_role_policy_document, Tags=tags)
+    # Instance profile follows the installer convention: '<name>-worker' (not '<name>-worker-profile')
+    iam_resource.create_instance_profile(InstanceProfileName='unittest-real-worker', Tags=tags)
+    iam_resource.add_role_to_instance_profile(InstanceProfileName='unittest-real-worker',
+                                              RoleName='unittest-real-worker-role')
+
+    zombie_cluster_resources = ZombieClusterResources(
+        cluster_prefix=["kubernetes.io/cluster", "sigs.k8s.io/cluster-api-provider-aws/cluster"],
+        delete=True, cluster_tag='kubernetes.io/cluster/unittest-real-cluster',
+        resource_name='zombie_cluster_role', force_delete=True)
+    zombie_cluster_resources.zombie_cluster_role()
+
+    role_names = [role['RoleName'] for role in iam_resource.list_roles()['Roles']]
+    assert 'unittest-real-worker-role' not in role_names
+
+
+@mock_aws
 @pytest.mark.skip(reason='Skipping the zombie cluster user')
 def test_delete_iam_cluster_user():
     """


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [x] bug
- [ ] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Two related zombie_cluster_resource bugs:

1. Global resources (IAM roles, S3 buckets) had their ClusterDeleteDays day counter incremented once per region per day (~17x too fast), because the scan runs in all regions while these resources are global. Now global resource types are only processed in AWS_DEFAULT_GLOBAL_REGION, so the counter advances once per day and the grace period is honored.

2. Zombie IAM role deletion always failed: the instance-profile name was derived via resource_id.replace('role', 'profile'), which does not match the real profile name (installer convention is role '<name>-worker-role' with instance profile '<name>-worker'). remove_role_from_instance_profile raised NoSuchEntity and aborted before delete_role, so roles were never removed. Now the actual instance-profile name(s) from the API are used.

Adds tests reproducing both issues.

## For security reasons, all pull requests need to be approved first before running any automated CI
