### PR TITLE
Orion Cost metrics rollup policy

### DIFF
--- a/cloud_governance/main/environment_variables.py
+++ b/cloud_governance/main/environment_variables.py
@@ -164,6 +164,10 @@ class EnvironmentVariables:
         self._environment_variables_dict['orion_rollup_start_date'] = EnvironmentVariables.get_env('orion_rollup_start_date', '')
         self._environment_variables_dict['orion_rollup_end_date'] = EnvironmentVariables.get_env('orion_rollup_end_date', '')
         self._environment_variables_dict['orion_metrics_es_index'] = EnvironmentVariables.get_env('orion_metrics_es_index', 'cloud-governance-orion-metrics-index')
+        self._environment_variables_dict['orion_cost_rollup_start_date'] = EnvironmentVariables.get_env('orion_cost_rollup_start_date', '')
+        self._environment_variables_dict['orion_cost_rollup_end_date'] = EnvironmentVariables.get_env('orion_cost_rollup_end_date', '')
+        self._environment_variables_dict['orion_cost_es_index'] = EnvironmentVariables.get_env('orion_cost_es_index', 'cloud-governance-orion-cost-metrics-index')
+        self._environment_variables_dict['orion_cost_center'] = EnvironmentVariables.get_env('orion_cost_center', '')
         self._environment_variables_dict['ORION_OUTPUT_FILE'] = EnvironmentVariables.get_env('ORION_OUTPUT_FILE', '')
         self._environment_variables_dict['SLACK_API_TOKEN'] = EnvironmentVariables.get_env('SLACK_API_TOKEN', '')
         self._environment_variables_dict['SLACK_CHANNEL_NAME'] = EnvironmentVariables.get_env('SLACK_CHANNEL_NAME', '')
@@ -308,7 +312,7 @@ class EnvironmentVariables:
         self._environment_variables_dict['ADMIN_MAIL_LIST'] = EnvironmentVariables.get_env('ADMIN_MAIL_LIST', '')
         self._environment_variables_dict['SKIP_POLICIES_ALERT'] = literal_eval(
             EnvironmentVariables.get_env('SKIP_POLICIES_ALERT', '[]'))
-        if self._environment_variables_dict.get('policy') in ['send_aggregated_alerts', 'cloudability_cost_reports', 'orion_metrics_rollup', 'orion_alert_handler']:
+        if self._environment_variables_dict.get('policy') in ['send_aggregated_alerts', 'cloudability_cost_reports', 'orion_metrics_rollup', 'orion_alert_handler', 'orion_cost_metrics_rollup']:
             self._environment_variables_dict['COMMON_POLICIES'] = True
         # CRO -- Cloud Resource Orch
         self._environment_variables_dict[

--- a/cloud_governance/policy/common_policies/orion_cost_metrics_rollup.py
+++ b/cloud_governance/policy/common_policies/orion_cost_metrics_rollup.py
@@ -1,0 +1,228 @@
+from datetime import datetime, timezone, date
+import time
+
+from cloud_governance.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
+from cloud_governance.common.logger.init_logger import logger
+from cloud_governance.common.logger.logger_time_stamp import logger_time_stamp
+from cloud_governance.main.environment_variables import environment_variables
+
+
+class OrionCostMetricsRollup:
+    """
+    Rolls up multi-cloud monthly billing data for a single cost center into one
+    document per month, so Orion (change-point regression detection) can watch
+    the cost center's total spend - and each cloud's spend - as its own time
+    series.
+
+    Source is the shared multi-cloud billing index, which stores one row per
+    account per month per cloud, fed daily by the per-cloud cost-report jobs.
+    """
+
+    # Read from explicitly, rather than the shared 'es_index' env var, so the
+    # source index this rollup reads from is unaffected by whatever es_index a
+    # given invocation happens to default to.
+    SOURCE_ES_INDEX = 'cloud-governance-clouds-billing-reports'
+    # Only these policies carry real per-account monthly spend in the source
+    # index (AWS via payer billings, the other clouds via cost billing reports).
+    # spot_savings_analysis and cloudability_cost_reports rows are excluded -
+    # they are different metrics and would otherwise double-count / distort spend.
+    SPEND_POLICIES = ['cost_explorer_payer_billings', 'cost_billing_reports']
+    # Map the source CloudName values onto the per-cloud metric field names.
+    # AWSCLOUD is a stray legacy label folded into aws_cost so nothing is lost.
+    CLOUD_FIELD_MAP = {
+        'AWS': 'aws_cost',
+        'AWSCLOUD': 'aws_cost',
+        'AZURE': 'azure_cost',
+        'GCP': 'gcp_cost',
+        'IBM Cloud': 'ibm_cost',
+    }
+    PER_CLOUD_FIELDS = ['aws_cost', 'azure_cost', 'gcp_cost', 'ibm_cost']
+
+    def __init__(self):
+        self.__environment_variables_dict = environment_variables.environment_variables_dict
+        self.__es_host = self.__environment_variables_dict.get('es_host', '')
+        self.__es_port = self.__environment_variables_dict.get('es_port', '')
+        self.__elastic_operations = ElasticSearchOperations(es_host=self.__es_host, es_port=self.__es_port) if self.__es_host else None
+        self.__destination_es_index = self.__environment_variables_dict.get('orion_cost_es_index', 'cloud-governance-orion-cost-metrics-index')
+        cost_center = self.__environment_variables_dict.get('orion_cost_center', '')
+        self.__cost_center = int(cost_center) if str(cost_center).strip() else None
+        self.__custom_start_date = self.__environment_variables_dict.get('orion_cost_rollup_start_date', '')
+        self.__custom_end_date = self.__environment_variables_dict.get('orion_cost_rollup_end_date', '')
+
+    @staticmethod
+    def __first_of_current_month():
+        """First day of the current UTC month - the boundary of 'in progress'."""
+        return datetime.now(timezone.utc).date().replace(day=1)
+
+    @staticmethod
+    def __last_completed_month():
+        """
+        Return (start, end) date strings for the most recently completed month
+        (i.e. the month before the current one).
+        """
+        first_current = OrionCostMetricsRollup.__first_of_current_month()
+        # subtracting a day drops into the previous month; day=1 gives its start
+        last_month_end = date(first_current.year, first_current.month, 1)
+        # step back one day into the previous month
+        prev = last_month_end.fromordinal(last_month_end.toordinal() - 1)
+        prev_start = prev.replace(day=1)
+        return prev_start.strftime('%Y-%m-%d'), prev.strftime('%Y-%m-%d')
+
+    def __build_query(self, start_date: str, end_date: str):
+        """
+        Build the month/cloud spend aggregation query for a date range.
+
+        Filters to the configured cost center, the spend-bearing policies, and
+        Actual > 0 (which also drops the forecast rows, whose Actual is 0).
+        @param start_date: Start date string (YYYY-MM-DD)
+        @param end_date: End date string (YYYY-MM-DD)
+        @return: ES query dict
+        """
+        return {
+            "size": 0,
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"term": {"CostCenter": self.__cost_center}},
+                        {"terms": {"policy.keyword": self.SPEND_POLICIES}},
+                        {"range": {"Actual": {"gt": 0}}},
+                        {"range": {"start_date": {"gte": start_date, "lte": end_date, "format": "yyyy-MM-dd"}}}
+                    ]
+                }
+            },
+            "aggs": {
+                "by_month": {
+                    "date_histogram": {"field": "start_date", "calendar_interval": "month", "format": "yyyy-MM-dd"},
+                    "aggs": {
+                        "by_cloud": {
+                            "terms": {"field": "CloudName.keyword", "size": 20},
+                            "aggs": {"spend": {"sum": {"field": "Actual"}}}
+                        },
+                        "total": {"sum": {"field": "Actual"}}
+                    }
+                }
+            }
+        }
+
+    def __parse_response(self, response: dict):
+        """
+        Walk the month -> cloud aggregation buckets and build one rollup
+        document per completed month. The current (in-progress) month is
+        skipped: it is still accruing, so its partial total would look like a
+        spurious drop to the change-point detector.
+        @param response: the 'aggregations' dict returned by post_query(result_agg=True)
+        @return: list of rollup documents
+        """
+        documents = []
+        if not response or 'by_month' not in response:
+            return documents
+
+        first_current = self.__first_of_current_month().strftime('%Y-%m-%d')
+
+        for month_bucket in response.get('by_month', {}).get('buckets', []):
+            month_start = month_bucket.get('key_as_string', '')[:10]
+            if not month_start:
+                continue
+            # skip the in-progress current (and any future) month
+            if month_start >= first_current:
+                continue
+            document = {field: 0 for field in self.PER_CLOUD_FIELDS}
+            for cloud_bucket in month_bucket.get('by_cloud', {}).get('buckets', []):
+                field = self.CLOUD_FIELD_MAP.get(cloud_bucket.get('key'))
+                if field:
+                    document[field] += round(cloud_bucket.get('spend', {}).get('value') or 0)
+            total = month_bucket.get('total', {}).get('value') or 0
+            document['total_cost'] = round(total)
+            month_label = month_start[:7]  # YYYY-MM
+            document['uuid'] = f'CC{self.__cost_center}-{month_label}'
+            document['timestamp'] = f'{month_start}T00:00:00Z'
+            document['account'] = f'CC{self.__cost_center}'
+            documents.append(document)
+        return documents
+
+    def __upsert_document(self, document: dict):
+        """
+        Create or update a single rollup document, keyed by its deterministic uuid.
+        @param document: rollup document, must include a 'uuid' key
+        """
+        doc_id = document['uuid']
+        try:
+            if self.__elastic_operations.verify_elastic_index_doc_id(index=self.__destination_es_index, doc_id=doc_id):
+                self.__elastic_operations.update_elasticsearch_index(
+                    index=self.__destination_es_index,
+                    id=doc_id,
+                    metadata=document
+                )
+            else:
+                self.__elastic_operations.upload_to_elasticsearch(
+                    index=self.__destination_es_index,
+                    data=document,
+                    id=doc_id
+                )
+        except Exception as err:
+            logger.warning(f"Update check failed for {doc_id}, trying create: {err}")
+            self.__elastic_operations.upload_to_elasticsearch(
+                index=self.__destination_es_index,
+                data=document,
+                id=doc_id
+            )
+
+    def __process_date_range(self, start_date: str, end_date: str):
+        """
+        Query and upsert rollup documents for a date range.
+        @param start_date: Start date string (YYYY-MM-DD)
+        @param end_date: End date string (YYYY-MM-DD)
+        @return: number of documents written
+        """
+        query = self.__build_query(start_date=start_date, end_date=end_date)
+        response = self.__elastic_operations.post_query(
+            query=query,
+            es_index=self.SOURCE_ES_INDEX,
+            result_agg=True
+        )
+        documents = self.__parse_response(response)
+        for document in documents:
+            self.__upsert_document(document)
+        return len(documents)
+
+    @logger_time_stamp
+    def run(self, start_date: str = None, end_date: str = None):
+        """
+        Roll up cost-center monthly spend into one document per completed month.
+
+        If start_date/end_date are given (directly, or via the
+        orion_cost_rollup_start_date/orion_cost_rollup_end_date env vars),
+        backfills that range. Otherwise, rolls up just the most recently
+        completed month - the incremental mode run daily in production, which
+        keeps the just-closed month fresh as late billing adjustments land.
+        @param start_date: Optional start date string (YYYY-MM-DD)
+        @param end_date: Optional end date string (YYYY-MM-DD)
+        @return: dict summarizing what was written
+        """
+        if not self.__elastic_operations:
+            logger.warning('ES not configured, skipping Orion cost metrics rollup')
+            return {'status': 'no_upload', 'message': 'ES not configured'}
+
+        if self.__cost_center is None:
+            logger.warning('orion_cost_center not configured, skipping Orion cost metrics rollup')
+            return {'status': 'skipped', 'message': 'orion_cost_center not configured'}
+
+        if not start_date:
+            start_date = self.__custom_start_date
+        if not end_date:
+            end_date = self.__custom_end_date
+
+        if bool(start_date) != bool(end_date):
+            logger.warning(f'Ignoring partial date range (start_date={start_date}, end_date={end_date}); both must be set to backfill. Falling back to incremental mode.')
+
+        if start_date and end_date:
+            logger.info(f'Backfilling Orion cost metrics rollup from {start_date} to {end_date}')
+            total_documents = self.__process_date_range(start_date, end_date)
+            logger.info(f'Orion cost metrics rollup backfill complete: {total_documents} documents written')
+            return {'status': 'success', 'documents_written': total_documents, 'start_date': start_date, 'end_date': end_date}
+
+        month_start, month_end = self.__last_completed_month()
+        logger.info(f'Running incremental Orion cost metrics rollup for {month_start[:7]}')
+        total_documents = self.__process_date_range(month_start, month_end)
+        logger.info(f'Orion cost metrics rollup complete for {month_start[:7]}: {total_documents} documents written')
+        return {'status': 'success', 'documents_written': total_documents, 'month': month_start[:7]}

--- a/cloud_governance/policy/common_policies/orion_cost_metrics_rollup.py
+++ b/cloud_governance/policy/common_policies/orion_cost_metrics_rollup.py
@@ -242,15 +242,23 @@ class OrionCostMetricsRollup:
             logger.warning('orion_cost_center not configured, skipping Orion cost metrics rollup')
             return {'status': 'skipped', 'message': 'orion_cost_center not configured'}
 
-        if not start_date:
+        # Separate direct input from configured defaults
+        # If either direct boundary is provided, both must come exclusively from direct (don't mix with config)
+        if start_date is not None or end_date is not None:
+            # At least one direct boundary provided; reject partial ranges
+            if bool(start_date) != bool(end_date):
+                logger.warning(f'Ignoring partial date range (start_date={start_date}, end_date={end_date}); both must be provided together. Falling back to incremental mode.')
+                start_date = ''
+                end_date = ''
+        else:
+            # No direct boundaries; try config defaults
             start_date = self.__custom_start_date
-        if not end_date:
             end_date = self.__custom_end_date
-
-        if bool(start_date) != bool(end_date):
-            logger.warning(f'Ignoring partial date range (start_date={start_date}, end_date={end_date}); both must be set to backfill. Falling back to incremental mode.')
-            start_date = ''
-            end_date = ''
+            # Check if config provides a partial range
+            if bool(start_date) != bool(end_date):
+                logger.warning(f'Ignoring partial date range from config (start_date={start_date}, end_date={end_date}); both must be set to backfill. Falling back to incremental mode.')
+                start_date = ''
+                end_date = ''
 
         if start_date and end_date:
             logger.info(f'Backfilling Orion cost metrics rollup from {start_date} to {end_date}')

--- a/cloud_governance/policy/common_policies/orion_cost_metrics_rollup.py
+++ b/cloud_governance/policy/common_policies/orion_cost_metrics_rollup.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone, date
+from datetime import datetime, timezone, date, timedelta
 import time
 
 from cloud_governance.common.elasticsearch.elasticsearch_operations import ElasticSearchOperations
@@ -67,6 +67,41 @@ class OrionCostMetricsRollup:
         prev = last_month_end.fromordinal(last_month_end.toordinal() - 1)
         prev_start = prev.replace(day=1)
         return prev_start.strftime('%Y-%m-%d'), prev.strftime('%Y-%m-%d')
+
+    def __split_date_range_by_month(self, start_date: str, end_date: str):
+        """
+        Split a date range into monthly (start, end) string chunks, to avoid
+        querying ES with an unbounded date range and ensure incremental progress.
+        @param start_date: Start date string (YYYY-MM-DD)
+        @param end_date: End date string (YYYY-MM-DD)
+        @return: list of (month_start, month_end) string tuples
+        """
+        if not start_date or not end_date:
+            raise ValueError(f"Both start_date and end_date must be provided. Got: start_date={start_date}, end_date={end_date}")
+
+        start = datetime.strptime(start_date, "%Y-%m-%d").date()
+        end = datetime.strptime(end_date, "%Y-%m-%d").date()
+
+        if start > end:
+            raise ValueError(f"start_date ({start_date}) must be <= end_date ({end_date})")
+
+        monthly_ranges = []
+        current_start = start
+
+        while current_start <= end:
+            if current_start.month == 12:
+                current_end = date(current_start.year + 1, 1, 1) - timedelta(days=1)
+            else:
+                current_end = date(current_start.year, current_start.month + 1, 1) - timedelta(days=1)
+            if current_end > end:
+                current_end = end
+            monthly_ranges.append((current_start.strftime("%Y-%m-%d"), current_end.strftime("%Y-%m-%d")))
+            if current_end.month == 12:
+                current_start = date(current_end.year + 1, 1, 1)
+            else:
+                current_start = date(current_end.year, current_end.month + 1, 1)
+
+        return monthly_ranges
 
     def __build_query(self, start_date: str, end_date: str):
         """
@@ -214,10 +249,18 @@ class OrionCostMetricsRollup:
 
         if bool(start_date) != bool(end_date):
             logger.warning(f'Ignoring partial date range (start_date={start_date}, end_date={end_date}); both must be set to backfill. Falling back to incremental mode.')
+            start_date = ''
+            end_date = ''
 
         if start_date and end_date:
             logger.info(f'Backfilling Orion cost metrics rollup from {start_date} to {end_date}')
-            total_documents = self.__process_date_range(start_date, end_date)
+            monthly_ranges = self.__split_date_range_by_month(start_date, end_date)
+            total_documents = 0
+            for i, (month_start, month_end) in enumerate(monthly_ranges, 1):
+                logger.info(f'Processing month {i}/{len(monthly_ranges)}: {month_start} to {month_end}')
+                total_documents += self.__process_date_range(month_start, month_end)
+                if i < len(monthly_ranges):
+                    time.sleep(0.5)
             logger.info(f'Orion cost metrics rollup backfill complete: {total_documents} documents written')
             return {'status': 'success', 'documents_written': total_documents, 'start_date': start_date, 'end_date': end_date}
 

--- a/tests/unittest/cloud_governance/policy/common_policies/test_orion_cost_metrics_rollup.py
+++ b/tests/unittest/cloud_governance/policy/common_policies/test_orion_cost_metrics_rollup.py
@@ -158,7 +158,8 @@ class TestOrionCostMetricsRollup:
         assert result['status'] == 'success'
         assert result['start_date'] == '2024-01-01'
         assert result['end_date'] == '2024-12-31'
-        assert self.mock_es_instance.post_query.call_count == 1
+        # Backfill chunks by month, so 12 months = 12 queries
+        assert self.mock_es_instance.post_query.call_count == 12
 
     def test_run_partial_date_range_falls_back_to_incremental(self):
         self.mock_es_instance.post_query.return_value = self._agg([])
@@ -167,3 +168,25 @@ class TestOrionCostMetricsRollup:
         assert 'month' in result
         assert 'start_date' not in result
         assert any('partial date range' in c.args[0].lower() for c in mock_logger.warning.call_args_list)
+
+    def test_split_date_range_by_month_chunks_correctly(self):
+        ranges = self.rollup._OrionCostMetricsRollup__split_date_range_by_month('2024-01-01', '2024-03-31')
+        assert len(ranges) == 3
+        assert ranges[0] == ('2024-01-01', '2024-01-31')
+        assert ranges[1] == ('2024-02-01', '2024-02-29')  # leap year
+        assert ranges[2] == ('2024-03-01', '2024-03-31')
+
+    def test_split_date_range_by_month_year_boundary(self):
+        ranges = self.rollup._OrionCostMetricsRollup__split_date_range_by_month('2024-11-15', '2025-02-28')
+        assert len(ranges) == 4
+        assert ranges[0] == ('2024-11-15', '2024-11-30')
+        assert ranges[1] == ('2024-12-01', '2024-12-31')
+        assert ranges[2] == ('2025-01-01', '2025-01-31')
+        assert ranges[3] == ('2025-02-01', '2025-02-28')
+
+    def test_run_backfill_chunks_by_month(self):
+        self.mock_es_instance.post_query.return_value = self._agg([])
+        result = self.rollup.run(start_date='2024-01-01', end_date='2024-03-31')
+        assert result['status'] == 'success'
+        # post_query called once per month (3 months)
+        assert self.mock_es_instance.post_query.call_count == 3

--- a/tests/unittest/cloud_governance/policy/common_policies/test_orion_cost_metrics_rollup.py
+++ b/tests/unittest/cloud_governance/policy/common_policies/test_orion_cost_metrics_rollup.py
@@ -1,0 +1,169 @@
+from unittest.mock import patch, MagicMock
+
+from cloud_governance.policy.common_policies.orion_cost_metrics_rollup import OrionCostMetricsRollup
+
+
+class TestOrionCostMetricsRollup:
+    """Test suite for OrionCostMetricsRollup class"""
+
+    def _make_rollup(self, env_overrides=None):
+        base_env = {
+            'es_host': 'localhost',
+            'es_port': '9200',
+            'orion_cost_es_index': 'cloud-governance-orion-cost-metrics-index',
+            'orion_cost_center': '999',  # generic test cost center (not internal)
+        }
+        if env_overrides:
+            base_env.update(env_overrides)
+        with patch('cloud_governance.policy.common_policies.orion_cost_metrics_rollup.environment_variables') as mock_env, \
+             patch('cloud_governance.policy.common_policies.orion_cost_metrics_rollup.ElasticSearchOperations') as mock_es_ops:
+            mock_env.environment_variables_dict = base_env
+            mock_es_instance = MagicMock()
+            mock_es_ops.return_value = mock_es_instance
+            rollup = OrionCostMetricsRollup()
+            rollup._mock_es = mock_es_instance
+            return rollup
+
+    def setup_method(self):
+        self.rollup = self._make_rollup()
+        self.mock_es_instance = self.rollup._mock_es
+
+    def _agg(self, buckets):
+        return {'by_month': {'buckets': buckets}}
+
+    def test_build_query_filters_cost_center_policies_and_actual(self):
+        """Query must scope to the configured cost center, spend policies, and Actual>0"""
+        query = self.rollup._OrionCostMetricsRollup__build_query('2026-01-01', '2026-07-31')
+        filters = query['query']['bool']['filter']
+
+        cc = [f for f in filters if 'term' in f and 'CostCenter' in f.get('term', {})]
+        assert cc and cc[0]['term']['CostCenter'] == 999
+
+        pol = [f for f in filters if 'terms' in f and 'policy.keyword' in f.get('terms', {})]
+        assert set(pol[0]['terms']['policy.keyword']) == set(OrionCostMetricsRollup.SPEND_POLICIES)
+
+        actual = [f for f in filters if 'range' in f and 'Actual' in f.get('range', {})]
+        assert actual and actual[0]['range']['Actual'] == {'gt': 0}
+
+        # monthly buckets
+        assert query['aggs']['by_month']['date_histogram']['calendar_interval'] == 'month'
+
+    @patch('cloud_governance.policy.common_policies.orion_cost_metrics_rollup.OrionCostMetricsRollup._OrionCostMetricsRollup__first_of_current_month')
+    def test_parse_response_builds_per_month_doc_with_cloud_split(self, mock_first):
+        """A completed month maps clouds to fields, fills missing clouds with 0, rounds to int"""
+        import datetime
+        mock_first.return_value = datetime.date(2026, 9, 1)  # current month = 2026-09
+
+        response = self._agg([
+            {
+                'key_as_string': '2026-07-01',
+                'by_cloud': {'buckets': [
+                    {'key': 'AWS', 'spend': {'value': 17512.4}},
+                    {'key': 'AZURE', 'spend': {'value': 14780.6}},
+                    {'key': 'IBM Cloud', 'spend': {'value': 191536.0}},
+                ]},
+                'total': {'value': 223829.0}
+            }
+        ])
+        docs = self.rollup._OrionCostMetricsRollup__parse_response(response)
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc['uuid'] == 'CC999-2026-07'
+        assert doc['account'] == 'CC999'
+        assert doc['timestamp'] == '2026-07-01T00:00:00Z'
+        assert doc['aws_cost'] == 17512
+        assert doc['azure_cost'] == 14781
+        assert doc['ibm_cost'] == 191536
+        assert doc['gcp_cost'] == 0  # missing cloud defaults to 0
+        assert doc['total_cost'] == 223829
+        assert all(isinstance(doc[f], int) for f in ['total_cost', 'aws_cost', 'azure_cost', 'gcp_cost', 'ibm_cost'])
+
+    @patch('cloud_governance.policy.common_policies.orion_cost_metrics_rollup.OrionCostMetricsRollup._OrionCostMetricsRollup__first_of_current_month')
+    def test_parse_response_skips_in_progress_and_future_months(self, mock_first):
+        """The current (in-progress) month and any future months must be excluded"""
+        import datetime
+        mock_first.return_value = datetime.date(2026, 9, 1)
+
+        response = self._agg([
+            {'key_as_string': '2026-08-01', 'by_cloud': {'buckets': [{'key': 'AWS', 'spend': {'value': 100}}]}, 'total': {'value': 100}},
+            {'key_as_string': '2026-09-01', 'by_cloud': {'buckets': [{'key': 'AWS', 'spend': {'value': 5}}]}, 'total': {'value': 5}},   # in-progress
+            {'key_as_string': '2026-10-01', 'by_cloud': {'buckets': [{'key': 'AWS', 'spend': {'value': 0}}]}, 'total': {'value': 0}},   # future
+        ])
+        docs = self.rollup._OrionCostMetricsRollup__parse_response(response)
+
+        assert len(docs) == 1
+        assert docs[0]['uuid'] == 'CC999-2026-08'
+
+    def test_parse_response_folds_awscloud_into_aws(self):
+        """The legacy AWSCLOUD label must be folded into aws_cost, not dropped"""
+        with patch.object(OrionCostMetricsRollup, '_OrionCostMetricsRollup__first_of_current_month', return_value=__import__('datetime').date(2026, 9, 1)):
+            response = self._agg([
+                {'key_as_string': '2026-05-01', 'by_cloud': {'buckets': [
+                    {'key': 'AWS', 'spend': {'value': 10}},
+                    {'key': 'AWSCLOUD', 'spend': {'value': 5}},
+                ]}, 'total': {'value': 15}}
+            ])
+            docs = self.rollup._OrionCostMetricsRollup__parse_response(response)
+        assert docs[0]['aws_cost'] == 15
+
+    def test_parse_response_handles_missing_aggregations(self):
+        assert self.rollup._OrionCostMetricsRollup__parse_response({}) == []
+        assert self.rollup._OrionCostMetricsRollup__parse_response(None) == []
+
+    def test_upsert_document_updates_when_exists(self):
+        self.mock_es_instance.verify_elastic_index_doc_id.return_value = True
+        doc = {'uuid': 'CC999-2026-07', 'total_cost': 100}
+        self.rollup._OrionCostMetricsRollup__upsert_document(doc)
+        self.mock_es_instance.update_elasticsearch_index.assert_called_once_with(
+            index='cloud-governance-orion-cost-metrics-index', id='CC999-2026-07', metadata=doc)
+        self.mock_es_instance.upload_to_elasticsearch.assert_not_called()
+
+    def test_upsert_document_creates_when_missing(self):
+        self.mock_es_instance.verify_elastic_index_doc_id.return_value = False
+        doc = {'uuid': 'CC999-2026-08', 'total_cost': 0}
+        self.rollup._OrionCostMetricsRollup__upsert_document(doc)
+        self.mock_es_instance.upload_to_elasticsearch.assert_called_once_with(
+            index='cloud-governance-orion-cost-metrics-index', data=doc, id='CC999-2026-08')
+
+    def test_upsert_document_falls_back_to_create_on_error(self):
+        self.mock_es_instance.verify_elastic_index_doc_id.side_effect = Exception('connection reset')
+        doc = {'uuid': 'CC999-2026-06', 'total_cost': 1}
+        self.rollup._OrionCostMetricsRollup__upsert_document(doc)
+        self.mock_es_instance.upload_to_elasticsearch.assert_called_once_with(
+            index='cloud-governance-orion-cost-metrics-index', data=doc, id='CC999-2026-06')
+
+    def test_run_without_es_configured(self):
+        rollup = self._make_rollup({'es_host': ''})
+        assert rollup.run() == {'status': 'no_upload', 'message': 'ES not configured'}
+
+    def test_run_skips_when_cost_center_unset(self):
+        """No cost center configured -> skip cleanly (no internal number hardcoded)"""
+        rollup = self._make_rollup({'orion_cost_center': ''})
+        result = rollup.run()
+        assert result['status'] == 'skipped'
+        assert 'orion_cost_center' in result['message']
+        rollup._mock_es.post_query.assert_not_called()
+
+    def test_run_incremental_processes_last_completed_month(self):
+        self.mock_es_instance.post_query.return_value = self._agg([])
+        result = self.rollup.run()
+        assert result['status'] == 'success'
+        assert 'month' in result
+        assert self.mock_es_instance.post_query.call_count == 1
+
+    def test_run_backfill_mode(self):
+        self.mock_es_instance.post_query.return_value = self._agg([])
+        result = self.rollup.run(start_date='2024-01-01', end_date='2024-12-31')
+        assert result['status'] == 'success'
+        assert result['start_date'] == '2024-01-01'
+        assert result['end_date'] == '2024-12-31'
+        assert self.mock_es_instance.post_query.call_count == 1
+
+    def test_run_partial_date_range_falls_back_to_incremental(self):
+        self.mock_es_instance.post_query.return_value = self._agg([])
+        with patch('cloud_governance.policy.common_policies.orion_cost_metrics_rollup.logger') as mock_logger:
+            result = self.rollup.run(start_date='2024-01-01')
+        assert 'month' in result
+        assert 'start_date' not in result
+        assert any('partial date range' in c.args[0].lower() for c in mock_logger.warning.call_args_list)

--- a/tests/unittest/cloud_governance/policy/common_policies/test_orion_cost_metrics_rollup.py
+++ b/tests/unittest/cloud_governance/policy/common_policies/test_orion_cost_metrics_rollup.py
@@ -169,6 +169,17 @@ class TestOrionCostMetricsRollup:
         assert 'start_date' not in result
         assert any('partial date range' in c.args[0].lower() for c in mock_logger.warning.call_args_list)
 
+    def test_run_direct_start_with_configured_end_falls_back(self):
+        """If caller provides start_date but only config has end_date, treat as partial and reject"""
+        self.mock_es_instance.post_query.return_value = self._agg([])
+        rollup = self._make_rollup({'orion_cost_rollup_end_date': '2024-12-31'})
+        with patch('cloud_governance.policy.common_policies.orion_cost_metrics_rollup.logger') as mock_logger:
+            result = rollup.run(start_date='2024-01-01')
+        # Should fall back to incremental, not backfill with mixed sources
+        assert 'month' in result
+        assert 'start_date' not in result
+        assert any('partial date range' in c.args[0].lower() for c in mock_logger.warning.call_args_list)
+
     def test_split_date_range_by_month_chunks_correctly(self):
         ranges = self.rollup._OrionCostMetricsRollup__split_date_range_by_month('2024-01-01', '2024-03-31')
         assert len(ranges) == 3


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
    - New cloud_governance/policy/common_policies/orion_cost_metrics_rollup.py (cloud-agnostic common policy, same dispatch as orion_metrics_rollup).
    - SOURCE_ES_INDEX = 'cloud-governance-clouds-billing-reports', DEST = 'cloud-governance-orion-cost-metrics-index', SPEND_POLICIES = [...].
    - Query: monthly date_histogram on start_date (calendar_interval=month) → sub-agg by_cloud (sum Actual) → build per-month doc. Filter to completed months.
    - Backfill mode (date range, chunked) + daily incremental (recompute completed months), upsert by deterministic uuid — reuse the exact patterns from orion_metrics_rollup.
  - Register in COMMON_POLICIES in environment_variables.py; add env vars (orion_cost_es_index, orion_cost_rollup_start/end_date).
  - Unit tests mirroring test_orion_metrics_rollup.py.

## For security reasons, all pull requests need to be approved first before running any automated CI
