### PR TITLE
Add recency filter and fix inf% display in Orion Slack notifier

### DIFF
--- a/cloud_governance/common/orion/slack_notifier.py
+++ b/cloud_governance/common/orion/slack_notifier.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from datetime import datetime, timezone
+import math
+from datetime import datetime, timezone, timedelta
 
 import requests
 
@@ -22,6 +23,12 @@ class OrionSlackNotifier:
     # per section's mrkdwn text.
     SLACK_MAX_BLOCKS = 50
     SLACK_MAX_SECTION_CHARS = 3000
+    # Orion's JSON output re-lists every change point in the entire historical
+    # series on every run, not just newly-detected ones. Without a recency
+    # cutoff, a change point from months ago would be re-alerted on every
+    # single daily run forever. Only surface change points recent enough to
+    # plausibly be from "what just happened", not "what Orion has ever seen".
+    RECENCY_WINDOW_DAYS = 35
 
     def __init__(self, slack_token: str, slack_channel: str):
         self.__slack_token = slack_token
@@ -54,27 +61,48 @@ class OrionSlackNotifier:
         return str(ts)
 
     @staticmethod
-    def extract_regressions(data_points: list) -> list:
+    def extract_regressions(data_points: list, reference_date: datetime = None) -> list:
         """
-        Walk the Orion JSON array and pull out change points with their
-        regressed metrics.
+        Walk the Orion JSON array and pull out recent change points with
+        their regressed metrics.
+
+        Change points older than RECENCY_WINDOW_DAYS (relative to
+        reference_date, default now) are skipped - see RECENCY_WINDOW_DAYS
+        for why. Entries whose timestamp can't be parsed are not filtered
+        out (fail open: a missed alert is worse than an extra one).
+
+        A metric's percentage_change can be NaN (0 -> 0, no real change -
+        skipped) or +/-inf (a zero baseline dividing into a nonzero value -
+        kept, but displayed without a misleading "inf%").
+        @param data_points: Orion's parsed JSON array
+        @param reference_date: reference point for the recency cutoff (for tests); defaults to now (UTC)
         """
+        if reference_date is None:
+            reference_date = datetime.now(timezone.utc)
+        cutoff = reference_date - timedelta(days=OrionSlackNotifier.RECENCY_WINDOW_DAYS)
+
         regressions = []
         for entry in data_points:
             if not entry.get('is_changepoint'):
                 continue
+            timestamp = entry.get('timestamp')
+            if isinstance(timestamp, (int, float)):
+                entry_date = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+                if entry_date < cutoff:
+                    continue
             metrics = entry.get('metrics', {})
             changed_metrics = []
             for metric_name, metric_data in metrics.items():
                 pct = metric_data.get('percentage_change', 0)
+                if isinstance(pct, float) and math.isnan(pct):
+                    continue
                 if pct != 0:
                     changed_metrics.append({
                         'name': metric_name,
                         'value': metric_data.get('value'),
-                        'percentage_change': round(pct, 2),
+                        'percentage_change': pct if (isinstance(pct, float) and math.isinf(pct)) else round(pct, 2),
                     })
             if changed_metrics:
-                timestamp = entry.get('timestamp')
                 regressions.append({
                     'timestamp': OrionSlackNotifier._format_timestamp(timestamp) if timestamp is not None else 'unknown',
                     'account': entry.get('account', entry.get('account.keyword', 'unknown')),
@@ -96,14 +124,21 @@ class OrionSlackNotifier:
         ts = regression.get('timestamp', 'unknown')
         lines = [f"*Date:* {ts}"]
         for m in regression['metrics']:
-            direction = 'increased' if m['percentage_change'] > 0 else 'decreased'
+            pct = m['percentage_change']
+            direction = 'increased' if pct > 0 else 'decreased'
             # Orion's JSON output keys metrics as "<config_name>_<metric_of_interest>"
             # (e.g. "zombieClusterResourceCountIncrease_zombie_cluster_resource_count").
             # Config metric names are plain camelCase with no underscores, so the part
             # before the first underscore is always just the readable config name.
             display_name = m['name'].split('_', 1)[0]
+            if isinstance(pct, float) and math.isinf(pct):
+                # A zero baseline makes the percentage mathematically undefined
+                # (division by zero) - showing "inf%" would be misleading.
+                magnitude = 'from a zero baseline (new)' if pct > 0 else 'to zero'
+            else:
+                magnitude = f'by `{abs(pct):.1f}%`'
             lines.append(
-                f"*{display_name}*: {direction} by `{abs(m['percentage_change']):.1f}%` (value: {m['value']})"
+                f"*{display_name}*: {direction} {magnitude} (value: {m['value']})"
             )
 
         blocks = []
@@ -198,13 +233,14 @@ class OrionSlackNotifier:
             logger.error('Slack API error: %s', response_data.get('error', 'unknown'))
         return response_data
 
-    def notify(self, file_path: str, account: str) -> dict:
+    def notify(self, file_path: str, account: str, reference_date: datetime = None) -> dict:
         """
         End-to-end: parse Orion output, extract regressions, post to Slack.
+        @param reference_date: reference point for the recency cutoff (for tests); defaults to now (UTC)
         Returns a summary dict.
         """
         data_points = self.parse_orion_json(file_path)
-        regressions = self.extract_regressions(data_points)
+        regressions = self.extract_regressions(data_points, reference_date=reference_date)
 
         if not regressions:
             logger.info('No regressions found for account %s', account)

--- a/cloud_governance/common/orion/slack_notifier.py
+++ b/cloud_governance/common/orion/slack_notifier.py
@@ -55,9 +55,14 @@ class OrionSlackNotifier:
         """
         Orion serializes the timestamp field as Unix epoch seconds in its
         JSON output, not ISO8601 - convert to a readable date for display.
+        A numeric-but-malformed value (NaN, +/-inf, out-of-range) fails the
+        conversion; fall back to the raw value rather than raising.
         """
         if isinstance(ts, (int, float)):
-            return datetime.fromtimestamp(ts, tz=timezone.utc).strftime('%Y-%m-%d')
+            try:
+                return datetime.fromtimestamp(ts, tz=timezone.utc).strftime('%Y-%m-%d')
+            except (ValueError, OverflowError, OSError):
+                return str(ts)
         return str(ts)
 
     @staticmethod
@@ -68,8 +73,9 @@ class OrionSlackNotifier:
 
         Change points older than RECENCY_WINDOW_DAYS (relative to
         reference_date, default now) are skipped - see RECENCY_WINDOW_DAYS
-        for why. Entries whose timestamp can't be parsed are not filtered
-        out (fail open: a missed alert is worse than an extra one).
+        for why. Entries whose timestamp can't be parsed - missing, wrong
+        type, or numeric-but-malformed (NaN/+-inf/out-of-range) - are not
+        filtered out (fail open: a missed alert is worse than an extra one).
 
         A metric's percentage_change can be NaN (0 -> 0, no real change -
         skipped) or +/-inf (a zero baseline dividing into a nonzero value -
@@ -87,8 +93,11 @@ class OrionSlackNotifier:
                 continue
             timestamp = entry.get('timestamp')
             if isinstance(timestamp, (int, float)):
-                entry_date = datetime.fromtimestamp(timestamp, tz=timezone.utc)
-                if entry_date < cutoff:
+                try:
+                    entry_date = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+                except (ValueError, OverflowError, OSError):
+                    entry_date = None
+                if entry_date is not None and entry_date < cutoff:
                     continue
             metrics = entry.get('metrics', {})
             changed_metrics = []

--- a/tests/unittest/cloud_governance/common/orion/test_slack_notifier.py
+++ b/tests/unittest/cloud_governance/common/orion/test_slack_notifier.py
@@ -1,6 +1,8 @@
 import json
+import math
 import os
 import tempfile
+from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 
 import requests
@@ -77,8 +79,12 @@ class TestOrionSlackNotifier:
         finally:
             os.unlink(path)
 
+    # Reference point for tests using SAMPLE_ORION_OUTPUT (2026-07-01/15/20),
+    # comfortably inside the 35-day recency window relative to those dates.
+    SAMPLE_REFERENCE_DATE = datetime(2026, 7, 25, tzinfo=timezone.utc)
+
     def test_extract_regressions_finds_changepoints_with_nonzero_change(self):
-        regressions = OrionSlackNotifier.extract_regressions(self.SAMPLE_ORION_OUTPUT)
+        regressions = OrionSlackNotifier.extract_regressions(self.SAMPLE_ORION_OUTPUT, reference_date=self.SAMPLE_REFERENCE_DATE)
         assert len(regressions) == 2
 
         first = regressions[0]
@@ -104,7 +110,7 @@ class TestOrionSlackNotifier:
                 }
             }
         ]
-        regressions = OrionSlackNotifier.extract_regressions(data)
+        regressions = OrionSlackNotifier.extract_regressions(data, reference_date=self.SAMPLE_REFERENCE_DATE)
         assert regressions[0]['timestamp'] == '2026-07-15'
 
     def test_extract_regressions_skips_non_changepoints(self):
@@ -129,10 +135,73 @@ class TestOrionSlackNotifier:
                 }
             }
         ]
-        assert OrionSlackNotifier.extract_regressions(data) == []
+        assert OrionSlackNotifier.extract_regressions(data, reference_date=self.SAMPLE_REFERENCE_DATE) == []
 
     def test_extract_regressions_handles_empty_list(self):
         assert OrionSlackNotifier.extract_regressions([]) == []
+
+    def test_extract_regressions_skips_change_points_older_than_recency_window(self):
+        """Orion re-lists every historical change point on every run; only recent ones should alert"""
+        reference_date = datetime(2026, 8, 1, tzinfo=timezone.utc)  # cutoff = 2026-06-27
+        data = [
+            {
+                'timestamp': 1767225600,  # 2026-01-01, far outside the 35-day window
+                'is_changepoint': True,
+                'metrics': {'someMetric_some_metric': {'value': 10, 'percentage_change': 50.0, 'labels': []}}
+            }
+        ]
+        assert OrionSlackNotifier.extract_regressions(data, reference_date=reference_date) == []
+
+    def test_extract_regressions_keeps_change_points_within_recency_window(self):
+        reference_date = datetime(2026, 8, 1, tzinfo=timezone.utc)  # cutoff = 2026-06-27
+        data = [
+            {
+                'timestamp': 1784073600,  # 2026-07-15, 17 days before reference_date
+                'is_changepoint': True,
+                'metrics': {'someMetric_some_metric': {'value': 10, 'percentage_change': 50.0, 'labels': []}}
+            }
+        ]
+        regressions = OrionSlackNotifier.extract_regressions(data, reference_date=reference_date)
+        assert len(regressions) == 1
+
+    def test_extract_regressions_fails_open_on_unparseable_timestamp(self):
+        """A change point with a non-numeric timestamp must not be silently dropped"""
+        reference_date = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        data = [
+            {
+                'timestamp': 'not-a-timestamp',
+                'is_changepoint': True,
+                'metrics': {'someMetric_some_metric': {'value': 10, 'percentage_change': 50.0, 'labels': []}}
+            }
+        ]
+        regressions = OrionSlackNotifier.extract_regressions(data, reference_date=reference_date)
+        assert len(regressions) == 1
+
+    def test_extract_regressions_skips_nan_percentage_change(self):
+        """A NaN percentage_change (0 -> 0) is not a real change and must not be surfaced"""
+        data = [
+            {
+                'timestamp': 1784073600,
+                'is_changepoint': True,
+                'metrics': {'someMetric_some_metric': {'value': 0, 'percentage_change': math.nan, 'labels': []}}
+            }
+        ]
+        reference_date = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        assert OrionSlackNotifier.extract_regressions(data, reference_date=reference_date) == []
+
+    def test_extract_regressions_keeps_inf_percentage_change(self):
+        """A zero-baseline divide (+/-inf) is a real change and must be kept, not dropped"""
+        data = [
+            {
+                'timestamp': 1784073600,
+                'is_changepoint': True,
+                'metrics': {'someMetric_some_metric': {'value': 100, 'percentage_change': math.inf, 'labels': []}}
+            }
+        ]
+        reference_date = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        regressions = OrionSlackNotifier.extract_regressions(data, reference_date=reference_date)
+        assert len(regressions) == 1
+        assert math.isinf(regressions[0]['metrics'][0]['percentage_change'])
 
     def test_format_slack_blocks_produces_header_and_sections(self):
         notifier = OrionSlackNotifier(slack_token='xoxb-test', slack_channel='test-channel')
@@ -178,6 +247,24 @@ class TestOrionSlackNotifier:
         assert '60.0%' in metric_block['text']['text']
         assert 'ec2StopCountDecrease' in metric_block['text']['text']
 
+    def test_format_slack_blocks_handles_zero_baseline_inf_change(self):
+        """A zero-baseline (+inf) change must render a readable message, not 'inf%'"""
+        notifier = OrionSlackNotifier(slack_token='xoxb-test', slack_channel='test-channel')
+        regressions = [
+            {
+                'timestamp': '2026-07-15',
+                'account': 'PERFSCALE',
+                'metrics': [
+                    {'name': 'gcpCostIncrease_gcp_cost', 'value': 500, 'percentage_change': math.inf},
+                ]
+            }
+        ]
+        blocks = notifier.format_slack_blocks('PERFSCALE', regressions)
+        text = blocks[3]['text']['text']
+        assert 'inf%' not in text.lower()
+        assert 'increased' in text
+        assert 'zero baseline' in text.lower()
+
     def test_format_slack_blocks_returns_empty_for_no_regressions(self):
         notifier = OrionSlackNotifier(slack_token='xoxb-test', slack_channel='test-channel')
         assert notifier.format_slack_blocks('PERFSCALE', []) == []
@@ -215,7 +302,7 @@ class TestOrionSlackNotifier:
         path = self._write_json_file(self.SAMPLE_ORION_OUTPUT)
         try:
             notifier = OrionSlackNotifier(slack_token='xoxb-test', slack_channel='alerts')
-            result = notifier.notify(file_path=path, account='PERFSCALE')
+            result = notifier.notify(file_path=path, account='PERFSCALE', reference_date=self.SAMPLE_REFERENCE_DATE)
 
             assert result['status'] == 'notified'
             assert result['regressions_count'] == 2
@@ -252,7 +339,7 @@ class TestOrionSlackNotifier:
         path = self._write_json_file(self.SAMPLE_ORION_OUTPUT)
         try:
             notifier = OrionSlackNotifier(slack_token='xoxb-test', slack_channel='bad-channel')
-            result = notifier.notify(file_path=path, account='PERFSCALE')
+            result = notifier.notify(file_path=path, account='PERFSCALE', reference_date=self.SAMPLE_REFERENCE_DATE)
 
             assert result['status'] == 'slack_error'
             assert result['slack_ok'] is False

--- a/tests/unittest/cloud_governance/common/orion/test_slack_notifier.py
+++ b/tests/unittest/cloud_governance/common/orion/test_slack_notifier.py
@@ -113,6 +113,11 @@ class TestOrionSlackNotifier:
         regressions = OrionSlackNotifier.extract_regressions(data, reference_date=self.SAMPLE_REFERENCE_DATE)
         assert regressions[0]['timestamp'] == '2026-07-15'
 
+    def test_format_timestamp_falls_back_on_malformed_numeric_value(self):
+        """A NaN/inf/out-of-range timestamp must render as a raw fallback, not raise"""
+        for bad_timestamp in (math.nan, math.inf, 99999999999999999999999):
+            assert OrionSlackNotifier._format_timestamp(bad_timestamp) == str(bad_timestamp)
+
     def test_extract_regressions_skips_non_changepoints(self):
         data = [
             {
@@ -176,6 +181,20 @@ class TestOrionSlackNotifier:
         ]
         regressions = OrionSlackNotifier.extract_regressions(data, reference_date=reference_date)
         assert len(regressions) == 1
+
+    def test_extract_regressions_fails_open_on_malformed_numeric_timestamp(self):
+        """A NaN/inf/out-of-range numeric timestamp must not crash the whole batch or drop the entry"""
+        reference_date = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        for bad_timestamp in (math.nan, math.inf, 99999999999999999999999):
+            data = [
+                {
+                    'timestamp': bad_timestamp,
+                    'is_changepoint': True,
+                    'metrics': {'someMetric_some_metric': {'value': 10, 'percentage_change': 50.0, 'labels': []}}
+                }
+            ]
+            regressions = OrionSlackNotifier.extract_regressions(data, reference_date=reference_date)
+            assert len(regressions) == 1
 
     def test_extract_regressions_skips_nan_percentage_change(self):
         """A NaN percentage_change (0 -> 0) is not a real change and must not be surfaced"""


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Orion's JSON output re-lists every change point in the full historical series on every run, not just new ones. Without a recency cutoff, an old change point would be re-alerted every single day forever. Only surface change points from the last 35 days.

Also handle the zero-baseline divide case: a metric going from 0 to nonzero produces +/-inf percentage_change, which rendered as a meaningless "inf%" in Slack messages. Now displayed as "from a zero baseline (new)" / "to zero" instead. NaN percentage_change (0 -> 0, no real change) is now skipped rather than treated as a change.

This is a prerequisite for wiring Orion cost-regression detection into the daily pipeline, which would otherwise flood Slack with repeated alerts for old, already-seen change points.

## For security reasons, all pull requests need to be approved first before running any automated CI
