### PR TITLE
Wire Orion cost-regression detection into the daily AWS cost job

### DIFF
--- a/jenkins/clouds/aws/daily/org_cost_explorer/Jenkinsfile
+++ b/jenkins/clouds/aws/daily/org_cost_explorer/Jenkinsfile
@@ -51,7 +51,24 @@ pipeline {
         }
         stage('Run the AWS Cost Reports') {
             steps {
-                sh 'python3 jenkins/clouds/aws/daily/org_cost_explorer/run_org_upload_es.py'
+                script {
+                    def orionCostBindings = []
+                    try {
+                        withCredentials([string(credentialsId: 'cloud-governance-slack-api-token', variable: 'SLACK_API_TOKEN'),
+                                         string(credentialsId: 'cloud-governance-slack-channel-name', variable: 'SLACK_CHANNEL_NAME'),
+                                         string(credentialsId: 'cloud-governance-orion-cost-center', variable: 'ORION_COST_CENTER')]) {
+                            // no-op: only checking that the credentials resolve
+                        }
+                        orionCostBindings = [string(credentialsId: 'cloud-governance-slack-api-token', variable: 'SLACK_API_TOKEN'),
+                                             string(credentialsId: 'cloud-governance-slack-channel-name', variable: 'SLACK_CHANNEL_NAME'),
+                                             string(credentialsId: 'cloud-governance-orion-cost-center', variable: 'ORION_COST_CENTER')]
+                    } catch (org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException e) {
+                        echo 'Orion cost-regression credentials not configured - Orion cost-regression alerts disabled for this run'
+                    }
+                    withCredentials(orionCostBindings) {
+                        sh 'python3 jenkins/clouds/aws/daily/org_cost_explorer/run_org_upload_es.py'
+                    }
+                }
             }
         }
         stage('Finalize Cleanup') {

--- a/jenkins/clouds/aws/daily/org_cost_explorer/run_org_upload_es.py
+++ b/jenkins/clouds/aws/daily/org_cost_explorer/run_org_upload_es.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 AWS_ACCESS_KEY_ID_DELETE_PERF = os.environ['AWS_ACCESS_KEY_ID_DELETE_PERF']
@@ -142,18 +143,30 @@ run_shell_cmd(cloudability_run_command)
 if SLACK_API_TOKEN and SLACK_CHANNEL_NAME and ORION_COST_CENTER:
     ORION_COST_ACCOUNT = f'CC{ORION_COST_CENTER}'
     ORION_COST_CONFIG_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))), 'orion-configs', 'cg-cost-regressions.yaml')
-    ORION_COST_TEST_NAME = 'cg-cost-regressions'
+    # Must stay in sync with the top-level test names in cg-cost-regressions.yaml.
+    # One metric per test block there (not multiple metrics sharing one block):
+    # Orion only resolves the "value" field correctly for the first metric in a
+    # given test block, silently nulling every metric after it - confirmed live
+    # against real data. So one Orion invocation now produces one output/data
+    # file pair per test name, which are merged below into a single alert.
+    ORION_COST_TEST_NAMES = [
+        'totalCostIncrease', 'totalCostDecrease',
+        'awsCostIncrease', 'awsCostDecrease',
+        'azureCostIncrease', 'azureCostDecrease',
+        'ibmCostIncrease', 'ibmCostDecrease',
+    ]
     ORION_COST_INDEX = 'cloud-governance-orion-cost-metrics-index'
 
     es_scheme = 'https' if str(ES_PORT) == '443' else 'http'
     es_auth = f'{ES_USER}:{ES_PASSWORD}@' if ES_USER else ''
     es_server = f'{es_scheme}://{es_auth}{ES_HOST}:{ES_PORT}'
     orion_cost_output_base = f'/tmp/orion-cost-output-{ORION_COST_ACCOUNT}.json'
-    orion_cost_output_file = f'/tmp/orion-cost-output-{ORION_COST_ACCOUNT}_{ORION_COST_TEST_NAME}.json'
     orion_cost_data_base = f'/tmp/orion-cost-data-{ORION_COST_ACCOUNT}.csv'
-    orion_cost_data_file = f'/tmp/orion-cost-data-{ORION_COST_ACCOUNT}-{ORION_COST_TEST_NAME}.csv'
+    orion_cost_output_files = [f'/tmp/orion-cost-output-{ORION_COST_ACCOUNT}_{name}.json' for name in ORION_COST_TEST_NAMES]
+    orion_cost_data_files = [f'/tmp/orion-cost-data-{ORION_COST_ACCOUNT}-{name}.csv' for name in ORION_COST_TEST_NAMES]
+    orion_cost_merged_file = f'/tmp/orion-cost-output-{ORION_COST_ACCOUNT}-merged.json'
 
-    run_shell_cmd(f'rm -f "{orion_cost_output_file}" "{orion_cost_data_file}"')
+    run_shell_cmd('rm -f ' + ' '.join(f'"{f}"' for f in orion_cost_output_files + orion_cost_data_files + [orion_cost_merged_file]))
 
     run_shell_cmd("echo Running Orion cost metrics rollup")
     rollup_status = run_shell_cmd(
@@ -164,16 +177,27 @@ if SLACK_API_TOKEN and SLACK_CHANNEL_NAME and ORION_COST_CENTER:
     else:
         try:
             run_shell_cmd("echo Running Orion cost regression analysis")
+            # Orion exits non-zero (2) when it detects regressions, so its exit
+            # status cannot gate the next step; presence of output files, which
+            # are written only when analysis completes, is used instead.
             run_shell_cmd(
                 f"""podman run --rm --name orion --net="host" -v "{ORION_COST_CONFIG_PATH}":"{ORION_COST_CONFIG_PATH}" -v /tmp:/tmp {QUAY_ORION_REPOSITORY} --es-server="{es_server}" --benchmark-index="{ORION_COST_INDEX}" --metadata-index="{ORION_COST_INDEX}" --hunter-analyze --input-vars='{{"account": "{ORION_COST_ACCOUNT}"}}' --config "{ORION_COST_CONFIG_PATH}" --output-format json --save-output-path "{orion_cost_output_base}" --save-data-path "{orion_cost_data_base}" """)
 
-            if os.path.exists(orion_cost_output_file):
+            merged_data_points = []
+            for output_file in orion_cost_output_files:
+                if os.path.exists(output_file):
+                    with open(output_file, 'r', encoding='utf-8') as f:
+                        merged_data_points.extend(json.load(f))
+
+            if merged_data_points:
+                with open(orion_cost_merged_file, 'w', encoding='utf-8') as f:
+                    json.dump(merged_data_points, f)
                 run_shell_cmd("echo Running Orion cost Slack alert handler")
                 run_shell_cmd(
-                    f"""podman run --rm --name cloud-governance --net="host" -v /tmp:/tmp -e account="{ORION_COST_ACCOUNT}" -e policy="orion_alert_handler" -e ORION_OUTPUT_FILE="{orion_cost_output_file}" -e SLACK_API_TOKEN="{SLACK_API_TOKEN}" -e SLACK_CHANNEL_NAME="{SLACK_CHANNEL_NAME}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+                    f"""podman run --rm --name cloud-governance --net="host" -v /tmp:/tmp -e account="{ORION_COST_ACCOUNT}" -e policy="orion_alert_handler" -e ORION_OUTPUT_FILE="{orion_cost_merged_file}" -e SLACK_API_TOKEN="{SLACK_API_TOKEN}" -e SLACK_CHANNEL_NAME="{SLACK_CHANNEL_NAME}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
             else:
                 run_shell_cmd("echo Skipping Orion cost alert - analysis produced no output")
         finally:
-            run_shell_cmd(f'rm -f "{orion_cost_output_file}" "{orion_cost_data_file}"')
+            run_shell_cmd('rm -f ' + ' '.join(f'"{f}"' for f in orion_cost_output_files + orion_cost_data_files + [orion_cost_merged_file]))
 else:
     run_shell_cmd("echo Skipping Orion cost-regression detection - SLACK_API_TOKEN/SLACK_CHANNEL_NAME/ORION_COST_CENTER not configured")

--- a/jenkins/clouds/aws/daily/org_cost_explorer/run_org_upload_es.py
+++ b/jenkins/clouds/aws/daily/org_cost_explorer/run_org_upload_es.py
@@ -1,5 +1,7 @@
 import json
 import os
+import shutil
+import tempfile
 
 AWS_ACCESS_KEY_ID_DELETE_PERF = os.environ['AWS_ACCESS_KEY_ID_DELETE_PERF']
 AWS_SECRET_ACCESS_KEY_DELETE_PERF = os.environ['AWS_SECRET_ACCESS_KEY_DELETE_PERF']
@@ -164,9 +166,8 @@ if SLACK_API_TOKEN and SLACK_CHANNEL_NAME and ORION_COST_CENTER:
     orion_cost_data_base = f'/tmp/orion-cost-data-{ORION_COST_ACCOUNT}.csv'
     orion_cost_output_files = [f'/tmp/orion-cost-output-{ORION_COST_ACCOUNT}_{name}.json' for name in ORION_COST_TEST_NAMES]
     orion_cost_data_files = [f'/tmp/orion-cost-data-{ORION_COST_ACCOUNT}-{name}.csv' for name in ORION_COST_TEST_NAMES]
-    orion_cost_merged_file = f'/tmp/orion-cost-output-{ORION_COST_ACCOUNT}-merged.json'
 
-    run_shell_cmd('rm -f ' + ' '.join(f'"{f}"' for f in orion_cost_output_files + orion_cost_data_files + [orion_cost_merged_file]))
+    run_shell_cmd('rm -f ' + ' '.join(f'"{f}"' for f in orion_cost_output_files + orion_cost_data_files))
 
     run_shell_cmd("echo Running Orion cost metrics rollup")
     rollup_status = run_shell_cmd(
@@ -190,14 +191,19 @@ if SLACK_API_TOKEN and SLACK_CHANNEL_NAME and ORION_COST_CENTER:
                         merged_data_points.extend(json.load(f))
 
             if merged_data_points:
-                with open(orion_cost_merged_file, 'w', encoding='utf-8') as f:
-                    json.dump(merged_data_points, f)
-                run_shell_cmd("echo Running Orion cost Slack alert handler")
-                run_shell_cmd(
-                    f"""podman run --rm --name cloud-governance --net="host" -v /tmp:/tmp -e account="{ORION_COST_ACCOUNT}" -e policy="orion_alert_handler" -e ORION_OUTPUT_FILE="{orion_cost_merged_file}" -e SLACK_API_TOKEN="{SLACK_API_TOKEN}" -e SLACK_CHANNEL_NAME="{SLACK_CHANNEL_NAME}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+                orion_cost_merge_dir = tempfile.mkdtemp(prefix=f'orion-cost-merge-{ORION_COST_ACCOUNT}-')
+                try:
+                    orion_cost_merged_file = os.path.join(orion_cost_merge_dir, 'orion-cost-output-merged.json')
+                    with open(orion_cost_merged_file, 'w', encoding='utf-8') as f:
+                        json.dump(merged_data_points, f)
+                    run_shell_cmd("echo Running Orion cost Slack alert handler")
+                    run_shell_cmd(
+                        f"""podman run --rm --name cloud-governance --net="host" -v "{orion_cost_merge_dir}":"{orion_cost_merge_dir}" -e account="{ORION_COST_ACCOUNT}" -e policy="orion_alert_handler" -e ORION_OUTPUT_FILE="{orion_cost_merged_file}" -e SLACK_API_TOKEN -e SLACK_CHANNEL_NAME="{SLACK_CHANNEL_NAME}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+                finally:
+                    shutil.rmtree(orion_cost_merge_dir, ignore_errors=True)
             else:
                 run_shell_cmd("echo Skipping Orion cost alert - analysis produced no output")
         finally:
-            run_shell_cmd('rm -f ' + ' '.join(f'"{f}"' for f in orion_cost_output_files + orion_cost_data_files + [orion_cost_merged_file]))
+            run_shell_cmd('rm -f ' + ' '.join(f'"{f}"' for f in orion_cost_output_files + orion_cost_data_files))
 else:
     run_shell_cmd("echo Skipping Orion cost-regression detection - SLACK_API_TOKEN/SLACK_CHANNEL_NAME/ORION_COST_CENTER not configured")

--- a/jenkins/clouds/aws/daily/org_cost_explorer/run_org_upload_es.py
+++ b/jenkins/clouds/aws/daily/org_cost_explorer/run_org_upload_es.py
@@ -18,6 +18,10 @@ S3_RESULTS_PATH = os.environ['S3_RESULTS_PATH']
 ATHENA_DATABASE_NAME = os.environ['ATHENA_DATABASE_NAME']
 ATHENA_TABLE_NAME = os.environ['ATHENA_TABLE_NAME']
 QUAY_CLOUD_GOVERNANCE_REPOSITORY = os.environ['QUAY_CLOUD_GOVERNANCE_REPOSITORY']
+QUAY_ORION_REPOSITORY = f'{QUAY_CLOUD_GOVERNANCE_REPOSITORY}-orion'
+SLACK_API_TOKEN = os.environ.get('SLACK_API_TOKEN', '')
+SLACK_CHANNEL_NAME = os.environ.get('SLACK_CHANNEL_NAME', '')
+ORION_COST_CENTER = os.environ.get('ORION_COST_CENTER', '')
 
 # Cloudability env variables
 
@@ -85,10 +89,10 @@ def run_shell_cmd(cmd: str):
     This method run the shell command
     :param cmd:
     :type cmd:
-    :return:
-    :rtype:
+    :return: the raw os.system status (0 on success)
+    :rtype: int
     """
-    os.system(cmd)
+    return os.system(cmd)
 
 
 def generate_shell_cmd(policy: str, env_variables: dict, mounted_volumes: str = ''):
@@ -134,3 +138,42 @@ cloudability_run_command = generate_shell_cmd(policy=CLOUDABILITY_POLICY,
 
 run_shell_cmd(f"echo Running the {CLOUDABILITY_POLICY}")
 run_shell_cmd(cloudability_run_command)
+
+if SLACK_API_TOKEN and SLACK_CHANNEL_NAME and ORION_COST_CENTER:
+    ORION_COST_ACCOUNT = f'CC{ORION_COST_CENTER}'
+    ORION_COST_CONFIG_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))), 'orion-configs', 'cg-cost-regressions.yaml')
+    ORION_COST_TEST_NAME = 'cg-cost-regressions'
+    ORION_COST_INDEX = 'cloud-governance-orion-cost-metrics-index'
+
+    es_scheme = 'https' if str(ES_PORT) == '443' else 'http'
+    es_auth = f'{ES_USER}:{ES_PASSWORD}@' if ES_USER else ''
+    es_server = f'{es_scheme}://{es_auth}{ES_HOST}:{ES_PORT}'
+    orion_cost_output_base = f'/tmp/orion-cost-output-{ORION_COST_ACCOUNT}.json'
+    orion_cost_output_file = f'/tmp/orion-cost-output-{ORION_COST_ACCOUNT}_{ORION_COST_TEST_NAME}.json'
+    orion_cost_data_base = f'/tmp/orion-cost-data-{ORION_COST_ACCOUNT}.csv'
+    orion_cost_data_file = f'/tmp/orion-cost-data-{ORION_COST_ACCOUNT}-{ORION_COST_TEST_NAME}.csv'
+
+    run_shell_cmd(f'rm -f "{orion_cost_output_file}" "{orion_cost_data_file}"')
+
+    run_shell_cmd("echo Running Orion cost metrics rollup")
+    rollup_status = run_shell_cmd(
+        f"""podman run --rm --net="host" --name cloud-governance -e policy="orion_cost_metrics_rollup" -e orion_cost_center="{ORION_COST_CENTER}" -e es_host="{ES_HOST}" -e es_port="{ES_PORT}" -e es_user="{ES_USER}" -e es_password="{ES_PASSWORD}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+
+    if rollup_status != 0:
+        run_shell_cmd("echo Skipping Orion cost analysis and alert - metrics rollup failed")
+    else:
+        try:
+            run_shell_cmd("echo Running Orion cost regression analysis")
+            run_shell_cmd(
+                f"""podman run --rm --name orion --net="host" -v "{ORION_COST_CONFIG_PATH}":"{ORION_COST_CONFIG_PATH}" -v /tmp:/tmp {QUAY_ORION_REPOSITORY} --es-server="{es_server}" --benchmark-index="{ORION_COST_INDEX}" --metadata-index="{ORION_COST_INDEX}" --hunter-analyze --input-vars='{{"account": "{ORION_COST_ACCOUNT}"}}' --config "{ORION_COST_CONFIG_PATH}" --output-format json --save-output-path "{orion_cost_output_base}" --save-data-path "{orion_cost_data_base}" """)
+
+            if os.path.exists(orion_cost_output_file):
+                run_shell_cmd("echo Running Orion cost Slack alert handler")
+                run_shell_cmd(
+                    f"""podman run --rm --name cloud-governance --net="host" -v /tmp:/tmp -e account="{ORION_COST_ACCOUNT}" -e policy="orion_alert_handler" -e ORION_OUTPUT_FILE="{orion_cost_output_file}" -e SLACK_API_TOKEN="{SLACK_API_TOKEN}" -e SLACK_CHANNEL_NAME="{SLACK_CHANNEL_NAME}" -e log_level="INFO" {QUAY_CLOUD_GOVERNANCE_REPOSITORY}""")
+            else:
+                run_shell_cmd("echo Skipping Orion cost alert - analysis produced no output")
+        finally:
+            run_shell_cmd(f'rm -f "{orion_cost_output_file}" "{orion_cost_data_file}"')
+else:
+    run_shell_cmd("echo Skipping Orion cost-regression detection - SLACK_API_TOKEN/SLACK_CHANNEL_NAME/ORION_COST_CENTER not configured")


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Adds a cost-center-scoped regression pipeline to run_org_upload_es.py: roll up today's data with orion_cost_metrics_rollup, run Orion's change-point analysis with cg-cost-regressions.yaml, and post any regressions via orion_alert_handler.

Unlike the existing per-account policy-metrics regression job, this runs once per day for the whole cost center (not once per AWS account), since the rollup already aggregates across accounts and clouds into one series
- looping per account would triple-post identical Slack alerts.

Gated on SLACK_API_TOKEN/SLACK_CHANNEL_NAME/ORION_COST_CENTER all being set; any missing one disables just this block, not the daily cost job. Jenkinsfile binds these as optional credentials using the same probe-then-bind pattern already used for the policy-metrics job's Orion Slack credentials, so a missing credential can't fail the whole pipeline.

## For security reasons, all pull requests need to be approved first before running any automated CI
