### PR TITLE
Show before/after shift and humanized names in Orion Slack alerts

### DIFF
--- a/cloud_governance/common/orion/slack_notifier.py
+++ b/cloud_governance/common/orion/slack_notifier.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import math
+import re
 from datetime import datetime, timezone, timedelta
 
 import requests
@@ -29,6 +30,9 @@ class OrionSlackNotifier:
     # single daily run forever. Only surface change points recent enough to
     # plausibly be from "what just happened", not "what Orion has ever seen".
     RECENCY_WINDOW_DAYS = 35
+    # Known cloud/service abbreviations that should stay all-caps when a
+    # config metric name (e.g. "awsCostIncrease") is humanized for display.
+    ACRONYMS = {'aws': 'AWS', 'ibm': 'IBM', 'gcp': 'GCP', 'ec2': 'EC2', 's3': 'S3'}
 
     def __init__(self, slack_token: str, slack_channel: str):
         self.__slack_token = slack_token
@@ -124,6 +128,53 @@ class OrionSlackNotifier:
         """Build a single mrkdwn section block."""
         return {'type': 'section', 'text': {'type': 'mrkdwn', 'text': text}}
 
+    @staticmethod
+    def _humanize_metric_name(name: str) -> str:
+        """
+        Turn a config metric name (e.g. "awsCostIncrease" or
+        "zombieClusterResourceCountIncrease") into a readable label
+        ("AWS Cost", "Zombie Cluster Resource Count") for display.
+        """
+        base = re.sub(r'(Increase|Decrease)$', '', name)
+        spaced = re.sub(r'(?<=[a-z0-9])(?=[A-Z])', ' ', base)
+        words = spaced.split()
+        return ' '.join(OrionSlackNotifier.ACRONYMS.get(w.lower(), w.capitalize()) for w in words)
+
+    @staticmethod
+    def _estimate_baseline(value, pct):
+        """
+        Best-effort "before" level implied by the current value and
+        percentage_change (value = baseline * (1 + pct/100)). None if it
+        can't be computed (missing value, or an exact -100% change where
+        the baseline is mathematically undefined from these two numbers
+        alone).
+        """
+        if value is None:
+            return None
+        denominator = 1 + pct / 100
+        if denominator == 0:
+            return None
+        return value / denominator
+
+    @staticmethod
+    def _format_metric_line(display_name: str, pct, value) -> str:
+        """
+        Describe one metric's change point in terms of the shift it
+        represents (before -> after), not just a bare percentage - a lasting
+        step to a new level is the whole point of change-point detection,
+        as opposed to a single noisy data point.
+        """
+        direction = 'increased' if pct > 0 else 'decreased'
+        if isinstance(pct, float) and math.isinf(pct):
+            # A zero baseline makes the percentage mathematically undefined
+            # (division by zero) - showing "inf%" would be misleading.
+            detail = 'increased from a zero baseline (new)' if pct > 0 else 'decreased to zero'
+            return f"*{display_name}*: {detail}"
+        baseline = OrionSlackNotifier._estimate_baseline(value, pct)
+        if baseline is None or value is None:
+            return f"*{display_name}*: {direction} by `{abs(pct):.1f}%`"
+        return f"*{display_name}*: {direction} from ~{round(baseline):,} to {value:,} ({pct:+.1f}%, sustained)"
+
     def _regression_section_blocks(self, regression: dict) -> list:
         """
         Build the section block(s) for one regression, splitting the text
@@ -133,22 +184,12 @@ class OrionSlackNotifier:
         ts = regression.get('timestamp', 'unknown')
         lines = [f"*Date:* {ts}"]
         for m in regression['metrics']:
-            pct = m['percentage_change']
-            direction = 'increased' if pct > 0 else 'decreased'
             # Orion's JSON output keys metrics as "<config_name>_<metric_of_interest>"
             # (e.g. "zombieClusterResourceCountIncrease_zombie_cluster_resource_count").
             # Config metric names are plain camelCase with no underscores, so the part
             # before the first underscore is always just the readable config name.
-            display_name = m['name'].split('_', 1)[0]
-            if isinstance(pct, float) and math.isinf(pct):
-                # A zero baseline makes the percentage mathematically undefined
-                # (division by zero) - showing "inf%" would be misleading.
-                magnitude = 'from a zero baseline (new)' if pct > 0 else 'to zero'
-            else:
-                magnitude = f'by `{abs(pct):.1f}%`'
-            lines.append(
-                f"*{display_name}*: {direction} {magnitude} (value: {m['value']})"
-            )
+            display_name = self._humanize_metric_name(m['name'].split('_', 1)[0])
+            lines.append(self._format_metric_line(display_name, m['percentage_change'], m['value']))
 
         blocks = []
         current, current_len = [], 0

--- a/tests/unittest/cloud_governance/common/orion/test_slack_notifier.py
+++ b/tests/unittest/cloud_governance/common/orion/test_slack_notifier.py
@@ -243,10 +243,14 @@ class TestOrionSlackNotifier:
         assert blocks[3]['type'] == 'section'
         assert '2026-07-15' in blocks[3]['text']['text']
         assert 'increased' in blocks[3]['text']['text']
-        assert '150.0%' in blocks[3]['text']['text']
-        # Only the readable config name should show, not the raw composite key
-        assert 'zombieClusterResourceCountIncrease' in blocks[3]['text']['text']
-        assert 'zombieClusterResourceCountIncrease_zombie_cluster_resource_count' not in blocks[3]['text']['text']
+        assert '+150.0%' in blocks[3]['text']['text']
+        assert 'sustained' in blocks[3]['text']['text']
+        # Before/after levels implied by value=25, percentage_change=150.0 (baseline = 25 / 2.5 = 10)
+        assert '~10' in blocks[3]['text']['text']
+        assert '25' in blocks[3]['text']['text']
+        # A humanized, readable name should show, not the raw camelCase/composite key
+        assert 'Zombie Cluster Resource Count' in blocks[3]['text']['text']
+        assert 'zombieClusterResourceCountIncrease' not in blocks[3]['text']['text']
 
     def test_format_slack_blocks_shows_decrease(self):
         notifier = OrionSlackNotifier(slack_token='xoxb-test', slack_channel='test-channel')
@@ -263,8 +267,10 @@ class TestOrionSlackNotifier:
 
         metric_block = blocks[3]
         assert 'decreased' in metric_block['text']['text']
-        assert '60.0%' in metric_block['text']['text']
-        assert 'ec2StopCountDecrease' in metric_block['text']['text']
+        assert '-60.0%' in metric_block['text']['text']
+        # Before/after levels implied by value=2, percentage_change=-60.0 (baseline = 2 / 0.4 = 5)
+        assert '~5' in metric_block['text']['text']
+        assert 'EC2 Stop Count' in metric_block['text']['text']
 
     def test_format_slack_blocks_handles_zero_baseline_inf_change(self):
         """A zero-baseline (+inf) change must render a readable message, not 'inf%'"""
@@ -283,6 +289,44 @@ class TestOrionSlackNotifier:
         assert 'inf%' not in text.lower()
         assert 'increased' in text
         assert 'zero baseline' in text.lower()
+
+    def test_humanize_metric_name_strips_direction_suffix_and_splits_camel_case(self):
+        assert OrionSlackNotifier._humanize_metric_name('totalCostIncrease') == 'Total Cost'
+        assert OrionSlackNotifier._humanize_metric_name('totalCostDecrease') == 'Total Cost'
+        assert OrionSlackNotifier._humanize_metric_name('zombieClusterResourceCountIncrease') == 'Zombie Cluster Resource Count'
+
+    def test_humanize_metric_name_uppercases_known_acronyms(self):
+        assert OrionSlackNotifier._humanize_metric_name('awsCostIncrease') == 'AWS Cost'
+        assert OrionSlackNotifier._humanize_metric_name('ibmCostDecrease') == 'IBM Cost'
+        assert OrionSlackNotifier._humanize_metric_name('ec2StopCountIncrease') == 'EC2 Stop Count'
+        assert OrionSlackNotifier._humanize_metric_name('s3InactiveCountIncrease') == 'S3 Inactive Count'
+
+    def test_estimate_baseline_for_increase_and_decrease(self):
+        # value = baseline * (1 + pct/100)
+        assert OrionSlackNotifier._estimate_baseline(223828, 74.46999013381509) == 223828 / 1.7446999013381509
+        assert OrionSlackNotifier._estimate_baseline(2, -60.0) == 5.0
+
+    def test_estimate_baseline_returns_none_when_undefined(self):
+        assert OrionSlackNotifier._estimate_baseline(None, 50.0) is None
+        # An exact -100% change makes baseline = value / 0, undefined from these two numbers alone
+        assert OrionSlackNotifier._estimate_baseline(0, -100.0) is None
+
+    def test_format_metric_line_shows_before_after_shift(self):
+        pct, value = 74.46999013381509, 223828
+        expected_baseline = round(value / (1 + pct / 100))
+        line = OrionSlackNotifier._format_metric_line('Total Cost', pct, value)
+        assert 'increased' in line
+        assert '+74.5%' in line
+        assert 'sustained' in line
+        assert '223,828' in line
+        assert f'~{expected_baseline:,}' in line
+
+    def test_format_metric_line_falls_back_when_baseline_undefined(self):
+        """An exact -100% change (baseline undefined) must still render, without a fabricated baseline"""
+        line = OrionSlackNotifier._format_metric_line('Total Cost', -100.0, 0)
+        assert 'decreased' in line
+        assert '100.0%' in line
+        assert '~' not in line
 
     def test_format_slack_blocks_returns_empty_for_no_regressions(self):
         notifier = OrionSlackNotifier(slack_token='xoxb-test', slack_channel='test-channel')


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x] enhancement
- [ ] documentation
- [ ] dependencies

## Description
Previously the alert only showed a bare percentage and the raw value ("increased by 74.5% (value: 223828)"), which required manual back-of-envelope math to see what actually changed. Now derives an approximate "before" baseline from the value and percentage_change Orion already reports (value = baseline * (1 + pct/100)) and shows both: "increased from ~128,290 to 223,828 (+74.5%, sustained)".

Also humanizes the raw config metric name for display (e.g. "awsCostIncrease" -> "AWS Cost", "zombieClusterResourceCountIncrease" -> "Zombie Cluster Resource Count") instead of showing the camelCase config key verbatim.

"sustained" reflects what change-point detection actually means: a lasting shift to a new level, not a single noisy data point - worth saying explicitly since that's the whole value proposition over a simple month-over-month threshold.

## For security reasons, all pull requests need to be approved first before running any automated CI
